### PR TITLE
iOS 26 UI improvements

### DIFF
--- a/Go Cycling/View/Cycle/RouteNameModalView.swift
+++ b/Go Cycling/View/Cycle/RouteNameModalView.swift
@@ -12,10 +12,9 @@ struct RouteNameModalView: View {
 
     @Environment(\.managedObjectContext) private var managedObjectContext
     @Environment(\.presentationMode) var presentationMode
-    
+
     @Binding var showEditModal: Bool
-    
-    @State private var showModally = true
+
     @State private var selectedNameIndex = 0
     @State private var namedRoutesViewSelection = NamedRoutesViewSelection.new
     
@@ -45,7 +44,7 @@ struct RouteNameModalView: View {
                 Text("Create a New Category").tag(NamedRoutesViewSelection.new)
                 Text("Use an Existing Category").tag(NamedRoutesViewSelection.existing)
             }
-            .pickerStyle(SegmentedPickerStyle())
+            .pickerStyle(.segmented)
             .padding(EdgeInsets.init(top: 0, leading: 10, bottom: 10, trailing: 10))
             
             switch namedRoutesViewSelection {
@@ -74,8 +73,8 @@ struct RouteNameModalView: View {
                 .padding()
                 Divider()
                 Button (action: {
-                    self.presentationMode.wrappedValue.dismiss()
-                    
+                    presentationMode.wrappedValue.dismiss()
+
                     if (self.bikeRideToEdit == nil) {
                         telemetryManager.sendCyclingSignal(
                             tab: telemetryTab,
@@ -108,7 +107,7 @@ struct RouteNameModalView: View {
                         }
                         }
                     }
-                    .listStyle(PlainListStyle())
+                    .listStyle(.plain)
                 }
                 else {
                     Text("There are no saved categories.")
@@ -131,7 +130,7 @@ struct RouteNameModalView: View {
                 .disabled(!(self.routeNamingViewModel.routeNames.count > 0))
                 Divider()
                 if (self.bikeRideToEdit != nil) {
-                    Button (action: {self.presentationMode.wrappedValue.dismiss()}) {
+                    Button (action: { presentationMode.wrappedValue.dismiss() }) {
                         Text("Cancel")
                             .bold()
                     }
@@ -139,8 +138,6 @@ struct RouteNameModalView: View {
                     Divider()
                 }
             }
-        }
-        .presentation(isModal: self.showModally) {
         }
         .onAppear {
             if (bikeRideToEdit != nil && bikeRideToEdit?.cyclingRouteName != "Uncategorized") {
@@ -188,9 +185,8 @@ struct RouteNameModalView: View {
                     time: ride.cyclingTime,
                     routeName: routeName)
             }
-            self.presentationMode.wrappedValue.dismiss()
+            presentationMode.wrappedValue.dismiss()
             self.showEditModal = false
-            self.showModally = false
         }
         else {
             let ride = self.bikeRideToEdit!
@@ -204,9 +200,8 @@ struct RouteNameModalView: View {
                 startTime: ride.cyclingStartTime,
                 time: ride.cyclingTime,
                 routeName: routeName)
-            self.presentationMode.wrappedValue.dismiss()
+            presentationMode.wrappedValue.dismiss()
             self.showEditModal = false
-            self.showModally = false
         }
     }
     
@@ -222,9 +217,8 @@ struct RouteNameModalView: View {
             startTime: ride.cyclingStartTime,
             time: ride.cyclingTime,
             routeName: "Uncategorized")
-        self.presentationMode.wrappedValue.dismiss()
+        presentationMode.wrappedValue.dismiss()
         self.showEditModal = false
-        self.showModally = false
     }
 }
 

--- a/Go Cycling/View/Cycle/RouteRenameModalView.swift
+++ b/Go Cycling/View/Cycle/RouteRenameModalView.swift
@@ -77,7 +77,7 @@ struct RouteRenameModalView: View {
                     }
                     }
                 }
-                .listStyle(PlainListStyle())
+                .listStyle(.plain)
             }
             else {
                 Text("There are no saved categories.")
@@ -90,7 +90,7 @@ struct RouteRenameModalView: View {
             .padding()
             .disabled(self.selectedNameIndex != -1 && !((self.text.count > 0)))
             Divider()
-            Button (action: {self.presentationMode.wrappedValue.dismiss()}) {
+            Button (action: { presentationMode.wrappedValue.dismiss() }) {
                 Text("Cancel")
                     .bold()
             }

--- a/Go Cycling/View/History/BikeRideFilterSheetView.swift
+++ b/Go Cycling/View/History/BikeRideFilterSheetView.swift
@@ -37,7 +37,7 @@ struct BikeRideFilterSheetView: View {
                         HStack {
                             Button (self.categories[index].name) {
                                 self.selectedName = index == 0 ? "" : self.categories[index].name
-                                self.presentationMode.wrappedValue.dismiss()
+                                presentationMode.wrappedValue.dismiss()
                                 
                                 telemetryManager.sendCyclingSignal(
                                     tab: telemetryTab,
@@ -49,11 +49,11 @@ struct BikeRideFilterSheetView: View {
                         }
                     }
                 }
-                .listStyle(InsetGroupedListStyle())
+                .listStyle(.insetGrouped)
             }
             Spacer()
             Divider()
-            Button (action: {self.presentationMode.wrappedValue.dismiss()}) {
+            Button (action: { presentationMode.wrappedValue.dismiss() }) {
                 Text("Cancel")
                     .foregroundColor(Color.blue)
                     .bold()

--- a/Go Cycling/View/History/BikeRideListView.swift
+++ b/Go Cycling/View/History/BikeRideListView.swift
@@ -18,19 +18,13 @@ struct BikeRideListView: View {
     
     @Environment(\.managedObjectContext) private var managedObjectContext
     
-    @State private var showingActionSheet = false
-    @State private var showingPopover = false
-    @State private var showingFilterPopover = false
     @State private var showingDeleteAlert = false
     @State private var shouldBeDeleted = false
     @State private var showingSheet = false
     @State private var sheetToPresent: SheetToPresent = .filter
     @State private var updateCategories = false
     @State private var toBeDeleted: IndexSet?
-    @State private var sortChoice: SortChoice = .dateDescending
     @State private var selectedName: String = Preferences.storedSelectedRoute()
-    
-    @State var sortDescriptor = NSSortDescriptor(keyPath: \BikeRide.cyclingTime, ascending: false)
     
     let telemetryManager = TelemetryManager.sharedTelemetryManager
     let telemetryTab = TelemetryTab.History
@@ -47,7 +41,7 @@ struct BikeRideListView: View {
                             Button (bikeRideViewModel.getFilterActionSheetTitle()) {
                                 self.sheetToPresent = .filter
                                 self.showingSheet = true
-                                
+
                                 telemetryManager.sendCyclingSignal(
                                     tab: telemetryTab,
                                     action: TelemetryCyclingAction.FilterClick
@@ -60,7 +54,7 @@ struct BikeRideListView: View {
                             Button ("Edit") {
                                 self.sheetToPresent = .edit
                                 self.showingSheet = true
-                                
+
                                 telemetryManager.sendCyclingSignal(
                                     tab: telemetryTab,
                                     action: TelemetryCyclingAction.EditCategory
@@ -69,26 +63,17 @@ struct BikeRideListView: View {
                         }
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        Button (bikeRideViewModel.getSortActionSheetTitle()) {
-                            if (min(geometry.size.width, geometry.size.height) < 600) {
-                                self.showingActionSheet = true
-                            }
-                            else {
-                                showingPopover.toggle()
-                            }
-                            
-                            telemetryManager.sendCyclingSignal(
-                                tab: telemetryTab,
-                                action: TelemetryCyclingAction.SortClick
-                            )
-                        }
-                        .popover(isPresented: $showingPopover) {
-                            BikeRideSortPopoverView(showingPopover: $showingPopover, sortChoice: $sortChoice)
+                        Menu(bikeRideViewModel.getSortActionSheetTitle()) {
+                            Button("Date Descending (Default)", action: bikeRideViewModel.sortByDateDescending)
+                            Button("Date Ascending", action: bikeRideViewModel.sortByDateAscending)
+                            Button("Distance Descending", action: bikeRideViewModel.sortByDistanceDescending)
+                            Button("Distance Ascending", action: bikeRideViewModel.sortByDistanceAscending)
+                            Button("Time Descending", action: bikeRideViewModel.sortByTimeDescending)
+                            Button("Time Ascending", action: bikeRideViewModel.sortByTimeAscending)
                         }
                     }
                 }
                 .onAppear {
-                    sortChoice = bikeRideViewModel.currentSortChoice
                     bikeRideViewModel.updateCategories()
                 }
                 // Filter action sheet
@@ -100,18 +85,6 @@ struct BikeRideListView: View {
                         RouteRenameModalView(showEditModal: $showingSheet, names: bikeRideViewModel.categories)
                     }
                 })
-                // Sort action sheet
-                .actionSheet(isPresented: $showingActionSheet, content: {
-                    ActionSheet(title: Text("Sort"), message: Text("Set your preferred sorting order."), buttons:[
-                        .default(Text("Date Descending (Default)"), action: bikeRideViewModel.sortByDateDescending),
-                        .default(Text("Date Ascending"), action: bikeRideViewModel.sortByDateAscending),
-                        .default(Text("Distance Descending"), action: bikeRideViewModel.sortByDistanceDescending),
-                        .default(Text("Distance Ascending"), action: bikeRideViewModel.sortByDistanceAscending),
-                        .default(Text("Time Descending"), action: bikeRideViewModel.sortByTimeDescending),
-                        .default(Text("Time Ascending"), action: bikeRideViewModel.sortByTimeAscending),
-                        .cancel()
-                    ])
-                })
                 .onChange(of: bikeRideViewModel.currentSortChoice, perform: { _ in
                     preferences.updateStringPreference(preference: CustomizablePreferences.sortingChoice, value: bikeRideViewModel.currentSortChoice.rawValue)
                     
@@ -119,22 +92,6 @@ struct BikeRideListView: View {
                         tab: telemetryTab,
                         action: TelemetryCyclingAction.SortApply
                     )
-                })
-                .onChange(of: sortChoice, perform: { value in
-                    switch sortChoice {
-                    case .distanceAscending:
-                        bikeRideViewModel.sortByDistanceAscending()
-                    case .distanceDescending:
-                        bikeRideViewModel.sortByDistanceDescending()
-                    case .dateAscending:
-                        bikeRideViewModel.sortByDateAscending()
-                    case .dateDescending:
-                        bikeRideViewModel.sortByDateDescending()
-                    case .timeAscending:
-                        bikeRideViewModel.sortByTimeAscending()
-                    case .timeDescending:
-                        bikeRideViewModel.sortByTimeDescending()
-                    }
                 })
                 .onChange(of: selectedName, perform: { _ in
                     bikeRideViewModel.setCurrentName(name: selectedName)

--- a/Go Cycling/View/History/BikeRideListView.swift
+++ b/Go Cycling/View/History/BikeRideListView.swift
@@ -38,7 +38,7 @@ struct BikeRideListView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         if (preferences.namedRoutes && bikeRideViewModel.filterEnabledCheck()) {
-                            Button (bikeRideViewModel.getFilterActionSheetTitle()) {
+                            Button {
                                 self.sheetToPresent = .filter
                                 self.showingSheet = true
 
@@ -46,12 +46,14 @@ struct BikeRideListView: View {
                                     tab: telemetryTab,
                                     action: TelemetryCyclingAction.FilterClick
                                 )
+                            } label: {
+                                Image(systemName: "line.3.horizontal.decrease")
                             }
                         }
                     }
                     ToolbarItem(placement: .navigationBarLeading) {
                         if (preferences.namedRoutes && bikeRideViewModel.editEnabledCheck()) {
-                            Button ("Edit") {
+                            Button {
                                 self.sheetToPresent = .edit
                                 self.showingSheet = true
 
@@ -59,6 +61,8 @@ struct BikeRideListView: View {
                                     tab: telemetryTab,
                                     action: TelemetryCyclingAction.EditCategory
                                 )
+                            } label: {
+                                Image(systemName: "pencil")
                             }
                         }
                     }

--- a/Go Cycling/View/History/BikeRideListView.swift
+++ b/Go Cycling/View/History/BikeRideListView.swift
@@ -76,8 +76,9 @@ struct BikeRideListView: View {
                 .onAppear {
                     bikeRideViewModel.updateCategories()
                 }
-                // Filter action sheet
-                .sheet(isPresented: $showingSheet, content: {
+                .sheet(isPresented: $showingSheet, onDismiss: {
+                    bikeRideViewModel.updateCategories()
+                }, content: {
                     switch sheetToPresent {
                     case .filter:
                         BikeRideFilterSheetView(showingSheet: $showingSheet, selectedName: $selectedName, names: bikeRideViewModel.categories)

--- a/Go Cycling/View/History/BikeRideListView.swift
+++ b/Go Cycling/View/History/BikeRideListView.swift
@@ -33,7 +33,7 @@ struct BikeRideListView: View {
         NavigationView {
             GeometryReader { (geometry) in
                 ListView(sortDescripter: bikeRideViewModel.getSortDescriptor(), name: bikeRideViewModel.currentName, showingDeleteAlert: $showingDeleteAlert, shouldBeDeleted: $shouldBeDeleted, updateCategories: $updateCategories)
-                .listStyle(PlainListStyle())
+                .listStyle(.plain)
                     .navigationBarTitle(self.getNavigationBarTitle(name: bikeRideViewModel.currentName), displayMode: .automatic)
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {

--- a/Go Cycling/View/History/SingleBikeRideView.swift
+++ b/Go Cycling/View/History/SingleBikeRideView.swift
@@ -80,13 +80,15 @@ struct SingleBikeRideView: View {
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 if (preferences.namedRoutes) {
-                    Button ("Edit") {
+                    Button {
                         self.showingEditPopover = true
-                        
+
                         telemetryManager.sendCyclingSignal(
                             tab: telemetryTab,
                             action: TelemetryCyclingAction.EditRoute
                         )
+                    } label: {
+                        Image(systemName: "pencil")
                     }
                 }
             }

--- a/Go Cycling/View/Settings/UnitsView.swift
+++ b/Go Cycling/View/Settings/UnitsView.swift
@@ -34,7 +34,7 @@ struct UnitsView: View {
                     }
             }
             .frame(maxWidth: 150)
-            .pickerStyle(SegmentedPickerStyle())
+            .pickerStyle(.segmented)
         }
         Toggle("Display Metrics on Map", isOn: $preferences.displayingMetrics)
             .onChange(of: preferences.displayingMetrics) { value in

--- a/Go Cycling/View/Statistics/BarChartView.swift
+++ b/Go Cycling/View/Statistics/BarChartView.swift
@@ -33,7 +33,7 @@ struct BarChartView: View {
                 Text("Time").tag(BarChartUnits.time)
                 Text("Routes").tag(BarChartUnits.numberOfRoutes)
             }
-            .pickerStyle(SegmentedPickerStyle())
+            .pickerStyle(.segmented)
             .padding(.bottom, 10)
             
             if (selectedValue != "") {


### PR DESCRIPTION
## Summary

- Replace deprecated `actionSheet` + popover sort UI with a native `Menu` in the History toolbar
- Switch Filter and Edit toolbar buttons to SF Symbols (`line.3.horizontal.decrease` and `pencil`)
- Switch Edit button in SingleBikeRideView to use pencil SF Symbol
- Fix category list not refreshing after renaming a route (missing `onDismiss` on sheet)
- Remove broken `.presentation(isModal:)` from RouteNameModalView
- Replace deprecated `SegmentedPickerStyle()`, `PlainListStyle()`, and `InsetGroupedListStyle()` with modern equivalents

## Test plan

- [x] History toolbar: Filter and Edit icons appear correctly, both open their respective sheets
- [x] History toolbar: Sort menu opens as a native dropdown with all six sort options
- [x] SingleBikeRideView: pencil icon appears in trailing toolbar and opens rename sheet
- [x] Rename a route, re-open the filter sheet — new name appears in the list
- [x] RouteNameModalView: categorise/rename a route from both Cycle and History tabs
- [x] Statistics bar chart picker and Settings units picker render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)