### PR TITLE
Fix Publishing-during-view-update warnings

### DIFF
--- a/Go Cycling/Core Data/BikeRideStorage.swift
+++ b/Go Cycling/Core Data/BikeRideStorage.swift
@@ -35,7 +35,9 @@ extension BikeRideStorage: NSFetchedResultsControllerDelegate {
         guard let savedBikeRides = controller.fetchedObjects as? [BikeRide]
         else { return }
 
-        storedBikeRides = savedBikeRides
+        DispatchQueue.main.async {
+            self.storedBikeRides = savedBikeRides
+        }
     }
 }
 

--- a/Go Cycling/Model/Preferences.swift
+++ b/Go Cycling/Model/Preferences.swift
@@ -129,37 +129,17 @@ class Preferences: ObservableObject {
         }
     }
     
-    // Converters for Views
+    // Read-only converters for Views — use updateBoolPreference/updateStringPreference to write
     var colourChoiceConverted: ColourChoice {
-        set {
-            colourChoice = newValue.rawValue
-        }
-        get {
-            ColourChoice(rawValue: colourChoice) ?? .blue
-        }
+        ColourChoice(rawValue: colourChoice) ?? .blue
     }
-    
+
     var sortingChoiceConverted: SortChoice {
-        set {
-            sortingChoice = newValue.rawValue
-        }
-        get {
-            SortChoice(rawValue: sortingChoice) ?? .dateDescending
-        }
+        SortChoice(rawValue: sortingChoice) ?? .dateDescending
     }
-    
+
     var metricsChoiceConverted: UnitsChoice {
-        set {
-            if (newValue.id == "metric") {
-                usingMetric = true
-            }
-            else {
-                usingMetric = false
-            }
-        }
-        get {
-            usingMetric ? .metric : .imperial
-        }
+        usingMetric ? .metric : .imperial
     }
     
     // Function to update class members

--- a/Go Cycling/View/Cycle/MapView.swift
+++ b/Go Cycling/View/Cycle/MapView.swift
@@ -122,7 +122,9 @@ struct MapView: UIViewRepresentable {
                                                         time: timeCycling)
                     
                     // Update CyclingRecords with thise new entry in case any new records were set
-                    records.updateCyclingRecords(speeds: locationManager.cyclingSpeeds, distance: locationManager.cyclingTotalDistance, startTime: cyclingStartTime, time: timeCycling)
+                    DispatchQueue.main.async {
+                        records.updateCyclingRecords(speeds: locationManager.cyclingSpeeds, distance: locationManager.cyclingTotalDistance, startTime: cyclingStartTime, time: timeCycling)
+                    }
                     
                     DispatchQueue.main.async {
                         locationManager.clearLocationArray()

--- a/Go Cycling/View/Cycle/MapView.swift
+++ b/Go Cycling/View/Cycle/MapView.swift
@@ -80,7 +80,9 @@ struct MapView: UIViewRepresentable {
             if cyclingStatus.isCycling {
                 if (!startedCycling) {
                     startedCycling = true
-                    locationManager.startedCycling()
+                    DispatchQueue.main.async {
+                        locationManager.startedCycling()
+                    }
                 }
                 let locationsCount = locationManager.cyclingLocations.count
                 switch locationsCount {
@@ -122,7 +124,9 @@ struct MapView: UIViewRepresentable {
                     // Update CyclingRecords with thise new entry in case any new records were set
                     records.updateCyclingRecords(speeds: locationManager.cyclingSpeeds, distance: locationManager.cyclingTotalDistance, startTime: cyclingStartTime, time: timeCycling)
                     
-                    locationManager.clearLocationArray()
+                    DispatchQueue.main.async {
+                        locationManager.clearLocationArray()
+                    }
                     locationManager.stopTrackingBackgroundLocation()
                 }
             }

--- a/Go Cycling/View/Settings/ColourView.swift
+++ b/Go Cycling/View/Settings/ColourView.swift
@@ -17,10 +17,20 @@ struct ColourView: View {
     let telemetryManager = TelemetryManager.sharedTelemetryManager
     let telemetryTabSection = TelemetrySettingsSection.Customization
     
+    var colourBinding: Binding<ColourChoice> {
+        Binding(
+            get: { preferences.colourChoiceConverted },
+            set: { value in
+                preferences.updateStringPreference(preference: CustomizablePreferences.colour, value: value.rawValue)
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.Colour)
+            }
+        )
+    }
+
     var body: some View {
         // The picker view within a form changed in iOS 16
         if #available(iOS 16.0, *) {
-            Picker("Colour", selection: $preferences.colourChoiceConverted) {
+            Picker("Colour", selection: colourBinding) {
                 Text("Red").tag(ColourChoice.red)
                 Text("Orange").tag(ColourChoice.orange)
                 Text("Yellow").tag(ColourChoice.yellow)
@@ -28,16 +38,12 @@ struct ColourView: View {
                 Text("Blue").tag(ColourChoice.blue)
                 Text("Indigo").tag(ColourChoice.indigo)
                 Text("Violet").tag(ColourChoice.violet)
-                    .navigationBarTitle("Choose your Colour", displayMode: .inline)
-                    .onChange(of: preferences.colourChoiceConverted) { _ in
-                        self.updateColourPreference(value: preferences.colourChoice)
-                    }
             }
-            // Use the navigation link picker style (how it looked before iOS 16)
+            .navigationBarTitle("Choose your Colour", displayMode: .inline)
             .pickerStyle(.navigationLink)
         }
         else {
-            Picker("Colour", selection: $preferences.colourChoiceConverted) {
+            Picker("Colour", selection: colourBinding) {
                 Text("Red").tag(ColourChoice.red)
                 Text("Orange").tag(ColourChoice.orange)
                 Text("Yellow").tag(ColourChoice.yellow)
@@ -45,21 +51,9 @@ struct ColourView: View {
                 Text("Blue").tag(ColourChoice.blue)
                 Text("Indigo").tag(ColourChoice.indigo)
                 Text("Violet").tag(ColourChoice.violet)
-                    .navigationBarTitle("Choose your Colour", displayMode: .inline)
-                    .onChange(of: preferences.colourChoiceConverted) { _ in
-                        self.updateColourPreference(value: preferences.colourChoice)
-                    }
             }
+            .navigationBarTitle("Choose your Colour", displayMode: .inline)
         }
-    }
-    
-    func updateColourPreference(value: String) {
-        preferences.updateStringPreference(preference: CustomizablePreferences.colour, value: value)
-        
-        telemetryManager.sendSettingsSignal(
-            section: telemetryTabSection,
-            action: TelemetrySettingsAction.Colour
-        )
     }
 }
 

--- a/Go Cycling/View/Settings/CyclingHistorySettingsView.swift
+++ b/Go Cycling/View/Settings/CyclingHistorySettingsView.swift
@@ -18,33 +18,27 @@ struct CyclingHistorySettingsView: View {
     let telemetryTabSection = TelemetrySettingsSection.History
     
     var body: some View {
-        Toggle("Route Categorization Enabled", isOn: $preferences.namedRoutes)
-            .onChange(of: preferences.namedRoutes) { value in
+        Toggle("Route Categorization Enabled", isOn: Binding(
+            get: { preferences.namedRoutes },
+            set: { value in
                 preferences.updateBoolPreference(preference: CustomizablePreferences.namedRoutes, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.RoutesEnabled
-                )
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.RoutesEnabled)
             }
-        Toggle("Deletion Enabled", isOn: $preferences.deletionEnabled)
-            .onChange(of: preferences.deletionEnabled) { value in
+        ))
+        Toggle("Deletion Enabled", isOn: Binding(
+            get: { preferences.deletionEnabled },
+            set: { value in
                 preferences.updateBoolPreference(preference: CustomizablePreferences.deletionEnabled, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.DeletionEnabled
-                )
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.DeletionEnabled)
             }
-        Toggle("Deletion Confirmation Alert", isOn: $preferences.deletionConfirmation)
-            .onChange(of: preferences.deletionConfirmation) { value in
+        ))
+        Toggle("Deletion Confirmation Alert", isOn: Binding(
+            get: { preferences.deletionConfirmation },
+            set: { value in
                 preferences.updateBoolPreference(preference: CustomizablePreferences.deletionConfirmation, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.DeletionConfirmtion
-                )
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.DeletionConfirmtion)
             }
+        ))
     }
 }
 

--- a/Go Cycling/View/Settings/CyclingView.swift
+++ b/Go Cycling/View/Settings/CyclingView.swift
@@ -18,16 +18,14 @@ struct CyclingView: View {
     let telemetryTabSection = TelemetrySettingsSection.Cycling
     
     var body: some View {
-        Toggle("Disable Auto-Lock", isOn: $preferences.autoLockDisabled)
-            .onChange(of: preferences.autoLockDisabled) { value in
-                UIApplication.shared.isIdleTimerDisabled = value
-                preferences.updateBoolPreference(preference: CustomizablePreferences.autoLockDisabled, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.AutoLock
-                )
-            }
+        Toggle("Disable Auto-Lock", isOn: Binding(
+            get: { preferences.autoLockDisabled },
+            set: { preferences.updateBoolPreference(preference: CustomizablePreferences.autoLockDisabled, value: $0) }
+        ))
+        .onChange(of: preferences.autoLockDisabled) { value in
+            UIApplication.shared.isIdleTimerDisabled = value
+            telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.AutoLock)
+        }
     }
 }
 

--- a/Go Cycling/View/Settings/SyncSettingsView.swift
+++ b/Go Cycling/View/Settings/SyncSettingsView.swift
@@ -22,21 +22,34 @@ struct SyncSettingsView: View {
     let telemetryManager = TelemetryManager.sharedTelemetryManager
     let telemetryTabSection = TelemetrySettingsSection.Sync
     
+    var iCloudBinding: Binding<Bool> {
+        Binding(
+            get: { preferences.iCloudOn },
+            set: { preferences.updateBoolPreference(preference: CustomizablePreferences.iCloudSync, value: $0) }
+        )
+    }
+
+    var healthBinding: Binding<Bool> {
+        Binding(
+            get: { preferences.healthSyncEnabled },
+            set: { preferences.updateBoolPreference(preference: CustomizablePreferences.healthSyncEnabled, value: $0) }
+        )
+    }
+
     var body: some View {
         // In iOS 16+ forms can have labels attached to content
         if #available(iOS 16.0, *) {
             // iCloud sync setting
             LabeledContent {
-                Toggle("", isOn: $preferences.iCloudOn)
-                    .onChange(of: preferences.iCloudOn) { value in
-                        self.updateSyncPreference(preference: CustomizablePreferences.iCloudSync, value: value)
+                Toggle("", isOn: iCloudBinding)
+                    .onChange(of: preferences.iCloudOn) { _ in
                         self.showingAlert = true
+                        telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.iCloud)
                     }
                 // Confirmation alert about restarting app due to iCloud setting change
                     .alert(isPresented: $showingAlert) {
                         Alert(title: Text("Restart is Required"),
                               message: Text("Please restart the application to \(preferences.iCloudOn ? "enable" : "disable") iCloud syncing for cycling routes.")
-                              
                         )
                     }
             } label: {
@@ -45,57 +58,33 @@ struct SyncSettingsView: View {
             }
             // HealthKit sync setting
             LabeledContent {
-                Toggle("", isOn: $preferences.healthSyncEnabled)
+                Toggle("", isOn: healthBinding)
                     .onChange(of: preferences.healthSyncEnabled) { value in
-                        self.updateSyncPreference(preference: CustomizablePreferences.healthSyncEnabled, value: value)
-                        if value {
-                            healthKitManager.requestAuthorization()
-                        }
+                        if value { healthKitManager.requestAuthorization() }
+                        telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.Health)
                     }
             } label: {
                 Label("Health", systemImage: "heart")
                 Text("Upload data to the Health app")
             }
         } else {
-            Toggle("iCloud Sync", isOn: $preferences.iCloudOn)
-                .onChange(of: preferences.iCloudOn) { value in
-                    self.updateSyncPreference(preference: CustomizablePreferences.iCloudSync, value: value)
+            Toggle("iCloud Sync", isOn: iCloudBinding)
+                .onChange(of: preferences.iCloudOn) { _ in
                     self.showingAlert = true
+                    telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.iCloud)
                 }
                 // Confirmation alert about restarting app due to iCloud setting change
                 .alert(isPresented: $showingAlert) {
                     Alert(title: Text("Restart is Required"),
                           message: Text("Please restart the application to \(preferences.iCloudOn ? "enable" : "disable") iCloud syncing for cycling routes.")
-                            
                     )
                 }
-            // TODO: Make sure this works in iOS 15
-            Toggle("Health Sync", isOn: $preferences.healthSyncEnabled)
+            Toggle("Health Sync", isOn: healthBinding)
                 .onChange(of: preferences.healthSyncEnabled) { value in
-                    self.updateSyncPreference(preference: CustomizablePreferences.healthSyncEnabled, value: value)
-                    if value {
-                        healthKitManager.requestAuthorization()
-                    }
+                    if value { healthKitManager.requestAuthorization() }
+                    telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.Health)
                 }
         }
-    }
-    
-    func updateSyncPreference(preference: CustomizablePreferences, value: Bool) {
-        preferences.updateBoolPreference(preference: preference, value: value)
-        
-        // Send the correct telemetry signal
-        var telemetryAction = TelemetrySettingsAction.iCloud
-        switch preference {
-        case .healthSyncEnabled:
-            telemetryAction = TelemetrySettingsAction.Health
-        default:
-            telemetryAction = TelemetrySettingsAction.iCloud
-        }
-        
-        telemetryManager.sendSettingsSignal(
-            section: telemetryTabSection,
-            action: telemetryAction
-        )
     }
 }
 

--- a/Go Cycling/View/Settings/UnitsView.swift
+++ b/Go Cycling/View/Settings/UnitsView.swift
@@ -21,39 +21,33 @@ struct UnitsView: View {
         HStack {
             Text("Prefered Units")
             Spacer()
-            Picker("Prefered Units", selection: $preferences.metricsChoiceConverted) {
+            Picker("Prefered Units", selection: Binding(
+                get: { preferences.metricsChoiceConverted },
+                set: { value in
+                    preferences.updateBoolPreference(preference: CustomizablePreferences.metric, value: value == .metric)
+                    telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.Units)
+                }
+            )) {
                 Text("Imperial").tag(UnitsChoice.imperial)
                 Text("Metric").tag(UnitsChoice.metric)
-                    .onChange(of: preferences.metricsChoiceConverted) { _ in
-                        preferences.updateBoolPreference(preference: CustomizablePreferences.metric, value: preferences.usingMetric)
-                        
-                        telemetryManager.sendSettingsSignal(
-                            section: telemetryTabSection,
-                            action: TelemetrySettingsAction.Units
-                        )
-                    }
             }
             .frame(maxWidth: 150)
             .pickerStyle(.segmented)
         }
-        Toggle("Display Metrics on Map", isOn: $preferences.displayingMetrics)
-            .onChange(of: preferences.displayingMetrics) { value in
+        Toggle("Display Metrics on Map", isOn: Binding(
+            get: { preferences.displayingMetrics },
+            set: { value in
                 preferences.updateBoolPreference(preference: CustomizablePreferences.displayingMetrics, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.MetricsOnMap
-                )
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.MetricsOnMap)
             }
-        Toggle("Large Metrics View", isOn: $preferences.largeMetrics)
-            .onChange(of: preferences.largeMetrics) { value in
+        ))
+        Toggle("Large Metrics View", isOn: Binding(
+            get: { preferences.largeMetrics },
+            set: { value in
                 preferences.updateBoolPreference(preference: CustomizablePreferences.largeMetrics, value: value)
-                
-                telemetryManager.sendSettingsSignal(
-                    section: telemetryTabSection,
-                    action: TelemetrySettingsAction.LargeMetrics
-                )
+                telemetryManager.sendSettingsSignal(section: telemetryTabSection, action: TelemetrySettingsAction.LargeMetrics)
             }
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Three sources of \"Publishing changes from within view updates is not allowed\" warnings were identified and fixed.

**Root cause — `MapView.swift` (`updateUIView`):** `UIViewRepresentable.updateUIView` is called during SwiftUI's render pass. It was synchronously calling functions that mutate `@Published` properties on `LocationViewModel` and `CyclingRecords`, firing `objectWillChange` mid-render:
- `locationManager.startedCycling()` — when a ride begins
- `records.updateCyclingRecords(...)` — when a ride ends
- `locationManager.clearLocationArray()` — when a ride ends

**Root cause — `BikeRideStorage.swift`:** `NSFetchedResultsControllerDelegate.controllerDidChangeContent` can be invoked during a SwiftUI update cycle. Assigning directly to `storedBikeRides` (@Published) triggered the same warning.

**Fix for all:** Wrap the `@Published` mutations in `DispatchQueue.main.async`, deferring them to the next runloop iteration after the render pass completes.

**Also included:** Settings views refactored from `$preferences.xxx` + `onChange { persist }` (double-set pattern) to explicit `Binding(get:set:)` whose setter persists exactly once. `onChange` is kept only for genuine side effects (HealthKit auth, alert presentation, `UIApplication.isIdleTimerDisabled`). Architecturally cleaner and eliminates a redundant SwiftUI update cycle per interaction.

## Files changed

| File | Change |
|---|---|
| `MapView.swift` | Wrap `startedCycling()`, `updateCyclingRecords()`, and `clearLocationArray()` in `DispatchQueue.main.async` |
| `BikeRideStorage.swift` | Wrap `storedBikeRides = savedBikeRides` in `DispatchQueue.main.async` |
| `Preferences.swift` | Remove `set` from `colourChoiceConverted`, `sortingChoiceConverted`, `metricsChoiceConverted` — now read-only |
| `UnitsView.swift` | Explicit `Binding` for Picker and both Toggles; `onChange` removed |
| `ColourView.swift` | Explicit `Binding` via `colourBinding`; `updateColourPreference` helper removed |
| `CyclingHistorySettingsView.swift` | Explicit `Binding` for all three Toggles; `onChange` removed |
| `CyclingView.swift` | Explicit `Binding` for persistence; `onChange` kept only for `UIApplication.isIdleTimerDisabled` |
| `SyncSettingsView.swift` | `iCloudBinding`/`healthBinding` computed for persistence; `onChange` kept only for alert, HealthKit auth; `updateSyncPreference` helper removed |

## Test plan

- [ ] Start a cycling session — confirm \"Publishing changes from within view updates\" warning no longer appears in console
- [ ] Stop a cycling session — confirm no warning on route save or record update
- [ ] Open cycling history — confirm no warning when list loads or a ride is deleted
- [ ] Settings > Customization — change colour, confirm it persists
- [ ] Settings > Metrics — toggle units, metrics on map, large metrics
- [ ] Settings > History — toggle route categorization, deletion enabled/confirmation
- [ ] Settings > Cycling — toggle auto-lock, confirm screen stays on
- [ ] Settings > Sync — toggle iCloud (restart alert appears), toggle Health (auth prompt appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)