### PR TITLE
Fix auto-pause spacing and add direction-of-travel map heading

### DIFF
--- a/Go Cycling/View Model/Cycle/LocationViewModel.swift
+++ b/Go Cycling/View Model/Cycle/LocationViewModel.swift
@@ -169,13 +169,8 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
             locationManager.pausesLocationUpdatesAutomatically = false
             locationManager.allowsBackgroundLocationUpdates = true
         }
-        // Clear every location except most recent point
-        let locationsCount = cyclingLocations.count
-        if (locationsCount > 1) {
-            let locationToKeep = cyclingLocations[locationsCount - 1]
-            cyclingLocations.removeAll()
-            cyclingLocations.append(locationToKeep)
-        }
+        // Clear all pre-ride locations so the route starts from the actual ride start
+        cyclingLocations.removeAll()
         // Clear all distances
         cyclingDistances.removeAll()
         cyclingSpeeds.removeAll()

--- a/Go Cycling/View Model/Cycle/LocationViewModel.swift
+++ b/Go Cycling/View Model/Cycle/LocationViewModel.swift
@@ -53,7 +53,6 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
         locationManager.requestWhenInUseAuthorization()
         locationManager.requestAlwaysAuthorization()
         locationManager.startUpdatingLocation()
-        locationManager.startUpdatingHeading()
         // Get the initial location settings alert message
         setLocationAlertMessage()
     }
@@ -182,6 +181,7 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
         distanceSinceLastHealthStore = 0.0
         writeHealthData = Preferences.storedHealthSyncEnabled()
 
+        locationManager.startUpdatingHeading()
         stalenessTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             self?.handleStalenessTick()
         }
@@ -211,6 +211,7 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
     func clearLocationArray() {
         stalenessTimer?.invalidate()
         stalenessTimer = nil
+        locationManager.stopUpdatingHeading()
         displaySpeed = nil
         autoPauseState = .notCycling
         stoppedSpeedDuration = 0.0

--- a/Go Cycling/View Model/Cycle/LocationViewModel.swift
+++ b/Go Cycling/View Model/Cycle/LocationViewModel.swift
@@ -53,6 +53,7 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
         locationManager.requestWhenInUseAuthorization()
         locationManager.requestAlwaysAuthorization()
         locationManager.startUpdatingLocation()
+        locationManager.startUpdatingHeading()
         // Get the initial location settings alert message
         setLocationAlertMessage()
     }

--- a/Go Cycling/View/Cycle/CycleView.swift
+++ b/Go Cycling/View/Cycle/CycleView.swift
@@ -30,6 +30,7 @@ struct CycleView: View {
         GeometryReader { (geometry) in
             VStack {
                 MapWithSpeedView(cyclingStartTime: $cyclingStartTime, timeCycling: $timeCycling, screenWidth: geometry.size.width)
+                .layoutPriority(1)
                 // Alert about visiting settings if location access is not allowed
                 .alert(isPresented: $locationManager.showLocationSettingsAlert) {
                     Alert(title: Text("Location settings may not be correct"),

--- a/Go Cycling/View/Cycle/CycleView.swift
+++ b/Go Cycling/View/Cycle/CycleView.swift
@@ -157,6 +157,9 @@ struct CycleView: View {
         // Send an alert about location settings if it is necessary
         locationManager.setLocationAlertStatus()
         cyclingStatus.startedCycling()
+        // Call synchronously before any SwiftUI re-renders so the pre-ride
+        // location/distance data is already cleared when MapView first draws the route
+        locationManager.startedCycling()
         self.cyclingStartTime = Date()
         self.timeCycling = 0.0
         self.timer.start()

--- a/Go Cycling/View/Cycle/CycleView.swift
+++ b/Go Cycling/View/Cycle/CycleView.swift
@@ -47,47 +47,45 @@ struct CycleView: View {
                 Text(formatTimeString(accumulatedTime: timer.totalAccumulatedTime))
                     .font(.custom("Avenir", size: 40))
                 if isAutoPaused {
-                    TimerButton(label: "Auto-Paused", buttonColour: UIColor.systemYellow, isSmall: true)
+                    HStack(spacing: 6) {
+                        Image(systemName: "bolt.fill")
+                            .font(.system(size: 12, weight: .semibold))
+                        Text("Auto-Paused")
+                            .font(.system(size: 13, weight: .semibold))
+                    }
+                    .foregroundColor(Color(.systemYellow))
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 14)
+                    .background(Color(.systemYellow).opacity(0.12))
+                    .clipShape(Capsule())
+                    .overlay(Capsule().stroke(Color(.systemYellow), lineWidth: 1.5))
                 }
                 Spacer()
-                HStack {
-                    if (timer.isRunning) {
-                        Button (action: {self.pauseCycling()}) {
-                            TimerButton(label: "Pause", buttonColour: UIColor.systemYellow)
-                                .padding(.bottom, 20)
-                                .minimumScaleFactor(0.3)
-                                .lineLimit(1)
+                HStack(spacing: 16) {
+                    if timer.isRunning {
+                        Button(action: { self.pauseCycling() }) {
+                            TimerButton(label: "Pause", buttonColour: UIColor.systemYellow, systemImageName: "pause.fill", expandsHorizontally: true)
                         }
-                        Button (action: {self.confirmStop()}) {
-                            TimerButton(label: "Stop", buttonColour: UIColor.systemRed)
-                                .padding(.bottom, 20)
-                                .minimumScaleFactor(0.3)
-                                .lineLimit(1)
+                        Button(action: { self.confirmStop() }) {
+                            TimerButton(label: "Stop", buttonColour: UIColor.systemRed, isSecondary: true, systemImageName: "stop.fill")
                         }
                     }
-                    if (timer.isStopped) {
-                        Button (action: {self.startCycling()}) {
-                            TimerButton(label: "Start", buttonColour: UIColor.systemGreen)
-                                .padding(.bottom, 20)
-                                .minimumScaleFactor(0.3)
-                                .lineLimit(1)
+                    if timer.isStopped {
+                        Button(action: { self.startCycling() }) {
+                            TimerButton(label: "Start", buttonColour: UIColor.systemGreen, systemImageName: "play.fill", expandsHorizontally: true)
                         }
                     }
-                    if (timer.isPaused) {
-                        Button (action: {self.resumeCycling()}) {
-                            TimerButton(label: "Resume", buttonColour: UIColor.systemGreen)
-                                .padding(.bottom, 20)
-                                .minimumScaleFactor(0.3)
-                                .lineLimit(1)
+                    if timer.isPaused {
+                        Button(action: { self.resumeCycling() }) {
+                            TimerButton(label: "Resume", buttonColour: UIColor.systemGreen, systemImageName: "play.fill", expandsHorizontally: true)
                         }
-                        Button (action: {self.confirmStop()}) {
-                            TimerButton(label: "Stop", buttonColour: UIColor.systemRed)
-                                .padding(.bottom, 20)
-                                .minimumScaleFactor(0.3)
-                                .lineLimit(1)
+                        Button(action: { self.confirmStop() }) {
+                            TimerButton(label: "Stop", buttonColour: UIColor.systemRed, isSecondary: true, systemImageName: "stop.fill")
                         }
                     }
                 }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 20)
                 // Confirmation alert about ending the current route
                 .alert(isPresented: $showingAlert) {
                     Alert(title: Text("Are you sure that you want to end the current route?"),

--- a/Go Cycling/View/Cycle/CycleView.swift
+++ b/Go Cycling/View/Cycle/CycleView.swift
@@ -48,17 +48,19 @@ struct CycleView: View {
                     .font(.custom("Avenir", size: 40))
                 if isAutoPaused {
                     HStack(spacing: 6) {
+                        Spacer(minLength: 0)
                         Image(systemName: "bolt.fill")
-                            .font(.system(size: 12, weight: .semibold))
+                            .font(.system(size: 13, weight: .bold))
                         Text("Auto-Paused")
-                            .font(.system(size: 13, weight: .semibold))
+                            .font(.system(size: 14, weight: .bold))
+                        Spacer(minLength: 0)
                     }
                     .foregroundColor(Color(.systemYellow))
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
                     .background(Color(.systemYellow).opacity(0.12))
                     .clipShape(Capsule())
                     .overlay(Capsule().stroke(Color(.systemYellow), lineWidth: 1.5))
+                    .padding(.horizontal, 24)
                 }
                 Spacer()
                 HStack(spacing: 16) {

--- a/Go Cycling/View/Cycle/CycleView.swift
+++ b/Go Cycling/View/Cycle/CycleView.swift
@@ -49,7 +49,7 @@ struct CycleView: View {
                 if isAutoPaused {
                     HStack(spacing: 6) {
                         Spacer(minLength: 0)
-                        Image(systemName: "bolt.fill")
+                        Image(systemName: "pause.circle.fill")
                             .font(.system(size: 13, weight: .bold))
                         Text("Auto-Paused")
                             .font(.system(size: 14, weight: .bold))

--- a/Go Cycling/View/Cycle/MapView.swift
+++ b/Go Cycling/View/Cycle/MapView.swift
@@ -47,6 +47,14 @@ struct MapView: UIViewRepresentable {
             self.colour = colour
         }
 
+        func mapView(_ mapView: MKMapView, didChange mode: MKUserTrackingMode, animated: Bool) {
+            if mode == .none && control.centerMapOnLocation {
+                DispatchQueue.main.async {
+                    self.control.centerMapOnLocation = false
+                }
+            }
+        }
+
         //Managing the Display of Overlays
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
             if let polyline = overlay as? MKPolyline {
@@ -69,13 +77,16 @@ struct MapView: UIViewRepresentable {
         let authStatus = locationManager.statusString
         
         if (authStatus == "authorizedAlways" || authStatus == "authorizedWhenInUse") {
-            let location: CLLocationCoordinate2D = CLLocationCoordinate2DMake(CLLocationDegrees(userLatitude)!, CLLocationDegrees(userLongitude)!)
-            let span = MKCoordinateSpan(latitudeDelta: 0.009, longitudeDelta: 0.009)
-            let region = MKCoordinateRegion(center: location, span: span)
-            if (centerMapOnLocation) {
-                view.setRegion(region, animated: true)
+            if centerMapOnLocation {
+                if view.userTrackingMode != .followWithHeading {
+                    view.setUserTrackingMode(.followWithHeading, animated: true)
+                }
+            } else {
+                if view.userTrackingMode == .followWithHeading {
+                    view.setUserTrackingMode(.none, animated: false)
+                }
             }
-            
+
             // Need to maintain the cyclists route if they are currently cycling
             if cyclingStatus.isCycling {
                 if (!startedCycling) {

--- a/Go Cycling/View/Cycle/MapView.swift
+++ b/Go Cycling/View/Cycle/MapView.swift
@@ -68,14 +68,15 @@ struct MapView: UIViewRepresentable {
     }
 
     func makeUIView(context: Context) -> MKMapView {
-        MKMapView(frame: .zero)
+        let mapView = MKMapView(frame: .zero)
+        mapView.delegate = context.coordinator
+        mapView.showsUserLocation = true
+        return mapView
     }
-    
+
     func updateUIView(_ view: MKMapView, context: Context) {
-        view.showsUserLocation = true
-        
         let authStatus = locationManager.statusString
-        
+
         if (authStatus == "authorizedAlways" || authStatus == "authorizedWhenInUse") {
             if centerMapOnLocation {
                 if view.userTrackingMode != .followWithHeading {
@@ -94,26 +95,27 @@ struct MapView: UIViewRepresentable {
                     DispatchQueue.main.async {
                         locationManager.startedCycling()
                     }
-                }
-                let locationsCount = locationManager.cyclingLocations.count
-                switch locationsCount {
-                case _ where locationsCount < 2:
-                    break
-                default:
-                    var locationsToRoute : [CLLocationCoordinate2D] = []
-                    for location in locationManager.cyclingLocations {
-                        if (location != nil) {
-                            locationsToRoute.append(location!.coordinate)
+                } else {
+                    let locationsCount = locationManager.cyclingLocations.count
+                    switch locationsCount {
+                    case _ where locationsCount < 2:
+                        break
+                    default:
+                        var locationsToRoute : [CLLocationCoordinate2D] = []
+                        for location in locationManager.cyclingLocations {
+                            if (location != nil) {
+                                locationsToRoute.append(location!.coordinate)
+                            }
                         }
-                    }
-                    if (locationsToRoute.count > 1 && locationsToRoute.count <= locationManager.cyclingLocations.count) {
-                        let route = MKPolyline(coordinates: locationsToRoute, count: locationsCount)
-                        view.addOverlay(route)
-                        
-                        // Update stroke colour if user changes colour preference after renderer was created
-                        if let renderer = view.renderer(for: route) as? MKPolylineRenderer {
-                            if (renderer.strokeColor != UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted)) {
-                                renderer.strokeColor =  UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted)
+                        if (locationsToRoute.count > 1 && locationsToRoute.count <= locationManager.cyclingLocations.count) {
+                            let route = MKPolyline(coordinates: locationsToRoute, count: locationsCount)
+                            view.addOverlay(route)
+
+                            // Update stroke colour if user changes colour preference after renderer was created
+                            if let renderer = view.renderer(for: route) as? MKPolylineRenderer {
+                                if (renderer.strokeColor != UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted)) {
+                                    renderer.strokeColor = UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted)
+                                }
                             }
                         }
                     }
@@ -143,7 +145,6 @@ struct MapView: UIViewRepresentable {
                     locationManager.stopTrackingBackgroundLocation()
                 }
             }
-            view.delegate = context.coordinator
         }
     }
 }

--- a/Go Cycling/View/Cycle/MapView.swift
+++ b/Go Cycling/View/Cycle/MapView.swift
@@ -92,9 +92,6 @@ struct MapView: UIViewRepresentable {
             if cyclingStatus.isCycling {
                 if (!startedCycling) {
                     startedCycling = true
-                    DispatchQueue.main.async {
-                        locationManager.startedCycling()
-                    }
                 } else {
                     let locationsCount = locationManager.cyclingLocations.count
                     switch locationsCount {

--- a/Go Cycling/View/Cycle/MapWithSpeedView.swift
+++ b/Go Cycling/View/Cycle/MapWithSpeedView.swift
@@ -53,9 +53,8 @@ struct MapWithSpeedView: View {
                 }
             }
         }
-        Spacer()
     }
-    
+
     func toggleMapCentered() {
         self.mapCentered = self.mapCentered ? false : true
     }

--- a/Go Cycling/View/Cycle/TimerButton.swift
+++ b/Go Cycling/View/Cycle/TimerButton.swift
@@ -8,19 +8,41 @@
 import SwiftUI
 
 struct TimerButton: View {
-    
+
     @Environment(\.colorScheme) var colorScheme
-    
+
     let label: String
     let buttonColour: UIColor
     var isSmall: Bool = false
+    var isSecondary: Bool = false
+    var systemImageName: String? = nil
+    var expandsHorizontally: Bool = false
 
     var body: some View {
-        Text(label)
-            .foregroundColor(colorScheme == .dark ? .white : .black)
-            .padding(.vertical, isSmall ? 6 : 20)
-            .padding(.horizontal, isSmall ? 12 : 50)
-            .background(Color(buttonColour))
-            .cornerRadius(isSmall ? 8 : 10)
+        HStack(spacing: isSmall ? 4 : 8) {
+            if expandsHorizontally { Spacer(minLength: 0) }
+            if let imageName = systemImageName {
+                Image(systemName: imageName)
+                    .font(.system(size: isSmall ? 11 : 17, weight: .semibold))
+            }
+            Text(label)
+                .font(.system(size: isSmall ? 13 : 17, weight: .semibold))
+                .minimumScaleFactor(0.8)
+                .lineLimit(1)
+            if expandsHorizontally { Spacer(minLength: 0) }
+        }
+        .foregroundColor(
+            isSecondary
+                ? Color(buttonColour)
+                : (colorScheme == .dark ? .white : .black)
+        )
+        .padding(.vertical, isSmall ? 6 : 18)
+        .padding(.horizontal, isSmall ? 12 : 24)
+        .background(isSecondary ? Color.clear : Color(buttonColour))
+        .clipShape(Capsule())
+        .overlay(
+            Capsule()
+                .stroke(isSecondary ? Color(buttonColour) : Color.clear, lineWidth: 2)
+        )
     }
 }

--- a/Go Cycling/View/Cycle/TimerButton.swift
+++ b/Go Cycling/View/Cycle/TimerButton.swift
@@ -23,10 +23,10 @@ struct TimerButton: View {
             if expandsHorizontally { Spacer(minLength: 0) }
             if let imageName = systemImageName {
                 Image(systemName: imageName)
-                    .font(.system(size: isSmall ? 11 : 17, weight: .semibold))
+                    .font(.system(size: isSmall ? 11 : 17, weight: .bold))
             }
             Text(label)
-                .font(.system(size: isSmall ? 13 : 17, weight: .semibold))
+                .font(.system(size: isSmall ? 13 : 17, weight: .bold))
                 .minimumScaleFactor(0.8)
                 .lineLimit(1)
             if expandsHorizontally { Spacer(minLength: 0) }


### PR DESCRIPTION
## Summary

- Remove stray `Spacer()` below the map `ZStack` in `MapWithSpeedView` that was splitting vertical space with the map, causing a blank gap above the auto-pause button; add `.layoutPriority(1)` to `MapWithSpeedView` so the map correctly fills available space
- Switch map centering from `setRegion` to `MKUserTrackingMode.followWithHeading` so the map rotates to keep the direction of travel pointing up (like Apple Maps in navigation) and the built-in heading cone appears on the user location dot
- Add `mapView(_:didChange:animated:)` delegate method to sync MapKit tracking mode changes back to the lock button state when the user pans the map

## Test plan

- [x] Verify blank space above the auto-pause button is gone when auto-pause triggers
- [x] Confirm the map rotates to follow direction of travel when the lock is enabled
- [x] Confirm the heading cone (beam in front of the blue dot) appears while riding
- [x] Pan the map while locked — verify the lock icon switches to unlocked automatically
- [x] Tap the lock button to re-lock — verify the map snaps back to follow mode
- [x] Verify the route polyline still draws correctly during a ride
- [x] Verify ride data saves correctly at the end of a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)