### PR TITLE
Add SwiftCharts statistics overhaul (iOS 16+)

### DIFF
--- a/Go Cycling.xcodeproj/project.pbxproj
+++ b/Go Cycling.xcodeproj/project.pbxproj
@@ -21,6 +21,15 @@
 		9D3808EA26D3709C0058DE1E /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D3808E926D3709C0058DE1E /* StatisticsView.swift */; };
 		9D55B9F726522D8D00B622E5 /* RouteRenameModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D55B9F626522D8D00B622E5 /* RouteRenameModalView.swift */; };
 		9D601E5626DEF6E100844CD1 /* ActivityAwardsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D601E5526DEF6E100844CD1 /* ActivityAwardsViewModel.swift */; };
+		5C7A0A772DCA4EC8A6301B40 /* ChartPeriod.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC0B121F5773497F8C758E70 /* ChartPeriod.swift */; };
+		A5C14C69D04041C189DAFC06 /* ChartDataPoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 033C6EF4DF8F4E9882BFE82D /* ChartDataPoint.swift */; };
+		9B36B84F275F40279DF3199D /* StatisticsChartsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EC307E08D38430BB4EC1FE9 /* StatisticsChartsViewModel.swift */; };
+		D44C55EB22EA4B9FAA4BF821 /* CyclingBarChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81299D31DF9348D68729394E /* CyclingBarChart.swift */; };
+		DF586DF102954377A82B408D /* ActivityHeatmapChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = B85AFADB1AB24BF5A79391D4 /* ActivityHeatmapChart.swift */; };
+		1C95F05D77EE49D3A9584731 /* SpeedTrendChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F658A9F110B49A5AC215D38 /* SpeedTrendChart.swift */; };
+		B4A833C07E3242DD8DCD8E76 /* CyclingChartsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F00257C7A4240F58BD1371A /* CyclingChartsDetailView.swift */; };
+		3DCD3758A7A842959A6F73D8 /* ActivityHeatmapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99CAB255859B41FCB50889B4 /* ActivityHeatmapDetailView.swift */; };
+		E015D343585C4918B9C7EF21 /* SpeedTrendDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A062C1FED5DD4ECDAD1E8E68 /* SpeedTrendDetailView.swift */; };
 		9D601E5926E0732100844CD1 /* SingleChartListCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D601E5826E0732100844CD1 /* SingleChartListCellView.swift */; };
 		9D601E5B26E085B700844CD1 /* CyclingChartsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D601E5A26E085B700844CD1 /* CyclingChartsViewModel.swift */; };
 		9D601E5D26E0992500844CD1 /* DateDistanceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D601E5C26E0992500844CD1 /* DateDistanceExtension.swift */; };
@@ -204,6 +213,15 @@
 		9D601E5526DEF6E100844CD1 /* ActivityAwardsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityAwardsViewModel.swift; sourceTree = "<group>"; };
 		9D601E5826E0732100844CD1 /* SingleChartListCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleChartListCellView.swift; sourceTree = "<group>"; };
 		9D601E5A26E085B700844CD1 /* CyclingChartsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclingChartsViewModel.swift; sourceTree = "<group>"; };
+		DC0B121F5773497F8C758E70 /* ChartPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartPeriod.swift; sourceTree = "<group>"; };
+		033C6EF4DF8F4E9882BFE82D /* ChartDataPoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChartDataPoint.swift; sourceTree = "<group>"; };
+		4EC307E08D38430BB4EC1FE9 /* StatisticsChartsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsChartsViewModel.swift; sourceTree = "<group>"; };
+		81299D31DF9348D68729394E /* CyclingBarChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclingBarChart.swift; sourceTree = "<group>"; };
+		B85AFADB1AB24BF5A79391D4 /* ActivityHeatmapChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityHeatmapChart.swift; sourceTree = "<group>"; };
+		4F658A9F110B49A5AC215D38 /* SpeedTrendChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTrendChart.swift; sourceTree = "<group>"; };
+		5F00257C7A4240F58BD1371A /* CyclingChartsDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CyclingChartsDetailView.swift; sourceTree = "<group>"; };
+		99CAB255859B41FCB50889B4 /* ActivityHeatmapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityHeatmapDetailView.swift; sourceTree = "<group>"; };
+		A062C1FED5DD4ECDAD1E8E68 /* SpeedTrendDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedTrendDetailView.swift; sourceTree = "<group>"; };
 		9D601E5C26E0992500844CD1 /* DateDistanceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateDistanceExtension.swift; sourceTree = "<group>"; };
 		9D601E5E26E09D4600844CD1 /* BarChartCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarChartCellView.swift; sourceTree = "<group>"; };
 		9D601E6026E09D9A00844CD1 /* BarChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarChartView.swift; sourceTree = "<group>"; };
@@ -417,6 +435,12 @@
 				9D601E5826E0732100844CD1 /* SingleChartListCellView.swift */,
 				9D601E5E26E09D4600844CD1 /* BarChartCellView.swift */,
 				9D601E6026E09D9A00844CD1 /* BarChartView.swift */,
+				81299D31DF9348D68729394E /* CyclingBarChart.swift */,
+				B85AFADB1AB24BF5A79391D4 /* ActivityHeatmapChart.swift */,
+				4F658A9F110B49A5AC215D38 /* SpeedTrendChart.swift */,
+				5F00257C7A4240F58BD1371A /* CyclingChartsDetailView.swift */,
+				99CAB255859B41FCB50889B4 /* ActivityHeatmapDetailView.swift */,
+				A062C1FED5DD4ECDAD1E8E68 /* SpeedTrendDetailView.swift */,
 			);
 			path = Statistics;
 			sourceTree = "<group>";
@@ -426,6 +450,7 @@
 			children = (
 				9D601E5526DEF6E100844CD1 /* ActivityAwardsViewModel.swift */,
 				9D601E5A26E085B700844CD1 /* CyclingChartsViewModel.swift */,
+				4EC307E08D38430BB4EC1FE9 /* StatisticsChartsViewModel.swift */,
 			);
 			path = Statistics;
 			sourceTree = "<group>";
@@ -536,6 +561,8 @@
 				9DC7583A2809506300BB2953 /* CyclingRecords.swift */,
 				9DA60D5F287558D000072DA2 /* ReviewManager.swift */,
 				9DC845432D9CDF4A0068519E /* TelemetryManager.swift */,
+				DC0B121F5773497F8C758E70 /* ChartPeriod.swift */,
+				033C6EF4DF8F4E9882BFE82D /* ChartDataPoint.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1024,6 +1051,15 @@
 				9D2F48FB26507EC500094575 /* RouteNamingViewModel.swift in Sources */,
 				9D2F48FE265097F000094575 /* Category.swift in Sources */,
 				9D601E5626DEF6E100844CD1 /* ActivityAwardsViewModel.swift in Sources */,
+				5C7A0A772DCA4EC8A6301B40 /* ChartPeriod.swift in Sources */,
+				A5C14C69D04041C189DAFC06 /* ChartDataPoint.swift in Sources */,
+				9B36B84F275F40279DF3199D /* StatisticsChartsViewModel.swift in Sources */,
+				D44C55EB22EA4B9FAA4BF821 /* CyclingBarChart.swift in Sources */,
+				DF586DF102954377A82B408D /* ActivityHeatmapChart.swift in Sources */,
+				1C95F05D77EE49D3A9584731 /* SpeedTrendChart.swift in Sources */,
+				B4A833C07E3242DD8DCD8E76 /* CyclingChartsDetailView.swift in Sources */,
+				3DCD3758A7A842959A6F73D8 /* ActivityHeatmapDetailView.swift in Sources */,
+				E015D343585C4918B9C7EF21 /* SpeedTrendDetailView.swift in Sources */,
 				9D9E8BEF28AE179C0057BCAB /* SyncSettingsView.swift in Sources */,
 				AA0000022026051300000001 /* PrivacySettingsView.swift in Sources */,
 				9D9776E52633B0E70048B504 /* BikeRideListView.swift in Sources */,

--- a/Go Cycling/Core Data/BikeRide/BikeRide+Extensions.swift
+++ b/Go Cycling/Core Data/BikeRide/BikeRide+Extensions.swift
@@ -98,6 +98,61 @@ extension BikeRide {
         return categories
     }
     
+    // Fetch current and previous period rides for the new SwiftCharts path
+    static func fetchRidesForPeriod(_ period: ChartPeriod, calendar: Calendar = Calendar.current) -> (current: [BikeRide], previous: [BikeRide]) {
+        let context = PersistenceController.shared.container.viewContext
+
+        func fetch(from fromDate: Date, to toDate: Date) -> [BikeRide] {
+            let request: NSFetchRequest<BikeRide> = BikeRide.fetchRequest()
+            request.sortDescriptors = []
+            let fromPred = NSPredicate(format: "%@ <= %K", fromDate as NSDate, #keyPath(BikeRide.cyclingStartTime))
+            let toPred   = NSPredicate(format: "%K < %@",  #keyPath(BikeRide.cyclingStartTime), toDate as NSDate)
+            request.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [fromPred, toPred])
+            return (try? context.fetch(request)) ?? []
+        }
+
+        var cal = calendar
+        cal.timeZone = .current
+        let today    = cal.startOfDay(for: Date())
+        let tomorrow = cal.date(byAdding: .day, value: 1, to: today)!
+
+        switch period {
+        case .oneWeek:
+            let cFrom = cal.date(byAdding: .day, value: -6,  to: today)!
+            let pFrom = cal.date(byAdding: .day, value: -13, to: today)!
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: cFrom))
+
+        case .oneMonth:
+            let cFrom = cal.date(byAdding: .day, value: -29, to: today)!
+            let pFrom = cal.date(byAdding: .day, value: -59, to: today)!
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: cFrom))
+
+        case .threeMonths:
+            let cFrom = cal.date(byAdding: .day, value: -89,  to: today)!
+            let pFrom = cal.date(byAdding: .day, value: -179, to: today)!
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: cFrom))
+
+        case .sixMonths:
+            let cFrom = cal.date(byAdding: .day, value: -179, to: today)!
+            let pFrom = cal.date(byAdding: .day, value: -359, to: today)!
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: cFrom))
+
+        case .yearToDate:
+            let year = cal.component(.year, from: today)
+            var ytdComps = DateComponents(); ytdComps.year = year; ytdComps.month = 1; ytdComps.day = 1
+            let cFrom = cal.date(from: ytdComps) ?? today
+            var prevComps = DateComponents(); prevComps.year = year - 1; prevComps.month = 1; prevComps.day = 1
+            let pFrom = cal.date(from: prevComps) ?? today
+            let pTo   = cal.date(byAdding: .year, value: -1, to: tomorrow) ?? today
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: pTo))
+
+        case .oneYear:
+            let cFrom = cal.date(byAdding: .day, value: -364, to: today)!
+            let pFrom = cal.date(byAdding: .day, value: -729, to: today)!
+            return (fetch(from: cFrom, to: tomorrow), fetch(from: pFrom, to: cFrom))
+        }
+    }
+
     // Functions to get data for the charts on the statistics tab
     static func bikeRidesInPastWeek() -> [BikeRide] {
         let context = PersistenceController.shared.container.viewContext

--- a/Go Cycling/Model/ChartDataPoint.swift
+++ b/Go Cycling/Model/ChartDataPoint.swift
@@ -1,0 +1,24 @@
+//
+//  ChartDataPoint.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import Foundation
+
+struct ChartDataPoint: Identifiable {
+    let id = UUID()
+    let bucketDate: Date
+    var distance: Double = 0   // meters
+    var time: Double = 0       // seconds
+    var routes: Int = 0
+
+    func value(for metric: ChartMetric) -> Double {
+        switch metric {
+        case .distance: return distance
+        case .time:     return time
+        case .routes:   return Double(routes)
+        }
+    }
+}

--- a/Go Cycling/Model/ChartPeriod.swift
+++ b/Go Cycling/Model/ChartPeriod.swift
@@ -1,0 +1,81 @@
+//
+//  ChartPeriod.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import Foundation
+
+enum ChartPeriod: Int, CaseIterable, Identifiable {
+    case oneWeek = 0
+    case oneMonth
+    case threeMonths
+    case sixMonths
+    case yearToDate
+    case oneYear
+
+    var id: Int { rawValue }
+
+    var label: String {
+        switch self {
+        case .oneWeek:     return "1W"
+        case .oneMonth:    return "1M"
+        case .threeMonths: return "3M"
+        case .sixMonths:   return "6M"
+        case .yearToDate:  return "YTD"
+        case .oneYear:     return "1Y"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .oneWeek:     return "Past 7 Days"
+        case .oneMonth:    return "Past Month"
+        case .threeMonths: return "Past 3 Months"
+        case .sixMonths:   return "Past 6 Months"
+        case .yearToDate:  return "Year to Date"
+        case .oneYear:     return "Past Year"
+        }
+    }
+
+    var bucketComponent: Calendar.Component {
+        switch self {
+        case .oneWeek, .oneMonth:      return .day
+        case .threeMonths, .sixMonths: return .weekOfYear
+        case .yearToDate, .oneYear:    return .month
+        }
+    }
+
+    func formatXLabel(_ date: Date) -> String {
+        let f = DateFormatter()
+        switch self {
+        case .oneWeek:
+            f.dateFormat = "EEE"
+        case .oneMonth:
+            f.dateFormat = "d"
+        case .threeMonths, .sixMonths:
+            f.dateFormat = "MMM d"
+        case .yearToDate, .oneYear:
+            f.dateFormat = "MMM"
+        }
+        return f.string(from: date)
+    }
+}
+
+// Metrics displayed in the bar chart
+enum ChartMetric: Int, CaseIterable, Identifiable {
+    case distance = 0
+    case time
+    case routes
+
+    var id: Int { rawValue }
+
+    var label: String {
+        switch self {
+        case .distance: return "Distance"
+        case .time:     return "Time"
+        case .routes:   return "Routes"
+        }
+    }
+}

--- a/Go Cycling/Model/TelemetryManager.swift
+++ b/Go Cycling/Model/TelemetryManager.swift
@@ -101,6 +101,13 @@ enum TelemetryCyclingAction: String {
     case OneWeek = "clickedOn1Week"
     case FiveWeeks = "clickedOn5Weeks"
     case ThirtyWeeks = "clickedOn30Weeks"
+    case OneMonth = "clickedOn1Month"
+    case ThreeMonths = "clickedOn3Months"
+    case SixMonths = "clickedOn6Months"
+    case YearToDate = "clickedOnYTD"
+    case OneYear = "clickedOn1Year"
+    case HeatmapView = "clickedOnHeatmap"
+    case SpeedTrendView = "clickedOnSpeedTrend"
     case AwardUnlocked = "unlockedActivityAward"
 }
 

--- a/Go Cycling/View Model/Statistics/StatisticsChartsViewModel.swift
+++ b/Go Cycling/View Model/Statistics/StatisticsChartsViewModel.swift
@@ -1,0 +1,406 @@
+//
+//  StatisticsChartsViewModel.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import Foundation
+
+class StatisticsChartsViewModel: ObservableObject {
+    @Published var currentPoints: [ChartDataPoint] = []
+    @Published var previousPoints: [ChartDataPoint] = []
+    @Published var heatmapData: [Date: Int] = [:]
+    @Published var heatmapDistanceData: [Date: Double] = [:]
+    @Published var heatmapTimeData: [Date: Double] = [:]
+    @Published var speedPoints: [SpeedPoint] = []
+
+    @Published var totalCurrentDistance: Double = 0
+    @Published var totalCurrentTime: Double = 0
+    @Published var totalCurrentRoutes: Int = 0
+    @Published var totalPreviousDistance: Double = 0
+    @Published var totalPreviousTime: Double = 0
+    @Published var totalPreviousRoutes: Int = 0
+
+    struct SpeedPoint: Identifiable {
+        let id = UUID()
+        let date: Date
+        let speed: Double   // m/s
+    }
+
+    var distanceChangePct: Double {
+        guard totalPreviousDistance > 0 else { return totalCurrentDistance > 0 ? 100 : 0 }
+        return ((totalCurrentDistance - totalPreviousDistance) / totalPreviousDistance) * 100
+    }
+
+    var timeChangePct: Double {
+        guard totalPreviousTime > 0 else { return totalCurrentTime > 0 ? 100 : 0 }
+        return ((totalCurrentTime - totalPreviousTime) / totalPreviousTime) * 100
+    }
+
+    var routeCountChange: Int { totalCurrentRoutes - totalPreviousRoutes }
+
+    var avgCurrentSpeed: Double {
+        guard totalCurrentDistance > 0, totalCurrentTime > 0 else { return 0 }
+        return totalCurrentDistance / totalCurrentTime
+    }
+
+    var avgPreviousSpeed: Double {
+        guard totalPreviousDistance > 0, totalPreviousTime > 0 else { return 0 }
+        return totalPreviousDistance / totalPreviousTime
+    }
+
+    var speedChangePct: Double {
+        guard avgPreviousSpeed > 0 else { return avgCurrentSpeed > 0 ? 100 : 0 }
+        return ((avgCurrentSpeed - avgPreviousSpeed) / avgPreviousSpeed) * 100
+    }
+
+    init(period: ChartPeriod) {
+        loadData(for: period)
+    }
+
+    func loadData(for period: ChartPeriod) {
+        var cal = Calendar.current
+        cal.timeZone = .current
+
+        let (currentRides, previousRides) = BikeRide.fetchRidesForPeriod(period, calendar: cal)
+
+        currentPoints  = buildBuckets(rides: currentRides,  period: period, isCurrent: true,  calendar: cal)
+        previousPoints = buildBuckets(rides: previousRides, period: period, isCurrent: false, calendar: cal)
+
+        totalCurrentDistance  = currentRides.reduce(0)  { $0 + $1.cyclingDistance }
+        totalCurrentTime      = currentRides.reduce(0)  { $0 + $1.cyclingTime }
+        totalCurrentRoutes    = currentRides.count
+        totalPreviousDistance = previousRides.reduce(0) { $0 + $1.cyclingDistance }
+        totalPreviousTime     = previousRides.reduce(0) { $0 + $1.cyclingTime }
+        totalPreviousRoutes   = previousRides.count
+
+        heatmapData = [:]
+        heatmapDistanceData = [:]
+        heatmapTimeData = [:]
+        for ride in currentRides {
+            let day = cal.startOfDay(for: ride.cyclingStartTime)
+            heatmapData[day, default: 0] += 1
+            heatmapDistanceData[day, default: 0] += ride.cyclingDistance
+            heatmapTimeData[day, default: 0] += ride.cyclingTime
+        }
+
+        speedPoints = currentRides
+            .filter { $0.cyclingTime > 0 && $0.cyclingDistance > 0 }
+            .map { SpeedPoint(date: $0.cyclingStartTime, speed: $0.cyclingDistance / $0.cyclingTime) }
+            .sorted { $0.date < $1.date }
+
+        #if DEBUG
+        if totalCurrentRoutes == 0 {
+            loadTestData(for: period)
+        }
+        #endif
+    }
+
+    // MARK: - Bucketing
+
+    private func buildBuckets(rides: [BikeRide], period: ChartPeriod, isCurrent: Bool, calendar: Calendar) -> [ChartDataPoint] {
+        let slots = bucketDates(for: period, isCurrent: isCurrent, calendar: calendar)
+        var map: [Date: ChartDataPoint] = Dictionary(
+            uniqueKeysWithValues: slots.map { ($0, ChartDataPoint(bucketDate: $0)) }
+        )
+        for ride in rides {
+            if let key = bucketKey(for: ride.cyclingStartTime, period: period, slots: slots, calendar: calendar) {
+                map[key]?.distance += ride.cyclingDistance
+                map[key]?.time     += ride.cyclingTime
+                map[key]?.routes   += 1
+            }
+        }
+        return slots.compactMap { map[$0] }
+    }
+
+    private func bucketDates(for period: ChartPeriod, isCurrent: Bool, calendar: Calendar) -> [Date] {
+        let today = calendar.startOfDay(for: Date())
+        var dates: [Date] = []
+
+        switch period {
+        case .oneWeek:
+            let base = isCurrent ? 0 : -7
+            for i in 0..<7 {
+                if let d = calendar.date(byAdding: .day, value: base - 6 + i, to: today) { dates.append(d) }
+            }
+
+        case .oneMonth:
+            let base = isCurrent ? 0 : -30
+            for i in 0..<30 {
+                if let d = calendar.date(byAdding: .day, value: base - 29 + i, to: today) { dates.append(d) }
+            }
+
+        case .threeMonths:
+            let base = isCurrent ? 0 : -91
+            for i in 0..<13 {
+                if let d = calendar.date(byAdding: .day, value: base - 84 + (i * 7), to: today) { dates.append(d) }
+            }
+
+        case .sixMonths:
+            let base = isCurrent ? 0 : -182
+            for i in 0..<26 {
+                if let d = calendar.date(byAdding: .day, value: base - 175 + (i * 7), to: today) { dates.append(d) }
+            }
+
+        case .yearToDate:
+            let currentYear  = calendar.component(.year,  from: today)
+            let currentMonth = calendar.component(.month, from: today)
+            let targetYear   = isCurrent ? currentYear : currentYear - 1
+            for month in 1...max(1, currentMonth) {
+                var c = DateComponents(); c.year = targetYear; c.month = month; c.day = 1
+                if let d = calendar.date(from: c) { dates.append(d) }
+            }
+
+        case .oneYear:
+            let monthOffset = isCurrent ? 0 : -12
+            for i in 0..<12 {
+                let back = -(11 - i) + monthOffset
+                if let d = calendar.date(byAdding: .month, value: back, to: today) {
+                    var c = calendar.dateComponents([.year, .month], from: d)
+                    c.day = 1
+                    if let start = calendar.date(from: c) { dates.append(start) }
+                }
+            }
+        }
+
+        return dates
+    }
+
+    private func bucketKey(for date: Date, period: ChartPeriod, slots: [Date], calendar: Calendar) -> Date? {
+        switch period {
+        case .oneWeek, .oneMonth:
+            let day = calendar.startOfDay(for: date)
+            return slots.first { calendar.isDate($0, inSameDayAs: day) }
+
+        case .threeMonths, .sixMonths:
+            let day = calendar.startOfDay(for: date)
+            for i in 0..<slots.count {
+                let end = calendar.date(byAdding: .day, value: 7, to: slots[i]) ?? slots[i]
+                if day >= slots[i] && day < end { return slots[i] }
+            }
+            return nil
+
+        case .yearToDate, .oneYear:
+            let rideMonth = calendar.component(.month, from: date)
+            let rideYear  = calendar.component(.year,  from: date)
+            return slots.first {
+                calendar.component(.month, from: $0) == rideMonth &&
+                calendar.component(.year,  from: $0) == rideYear
+            }
+        }
+    }
+
+    // MARK: - Test Data
+
+    #if DEBUG
+    private func loadTestData(for period: ChartPeriod) {
+        var cal = Calendar.current
+        cal.timeZone = .current
+        let today = cal.startOfDay(for: Date())
+
+        func daysAgo(_ n: Int) -> Date { cal.date(byAdding: .day, value: -n, to: today) ?? today }
+        func monthsAgo(_ n: Int) -> Date {
+            var c = DateComponents(); c.month = -n
+            let d = cal.date(byAdding: c, to: today) ?? today
+            return cal.startOfDay(for: d)
+        }
+
+        // km → meters, minutes → seconds helpers
+        func km(_ v: Double) -> Double { v * 1000 }
+        func mins(_ v: Double) -> Double { v * 60 }
+
+        switch period {
+        case .oneWeek:
+            currentPoints = [
+                ChartDataPoint(bucketDate: daysAgo(6), distance: km(18.4), time: mins(52),  routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(5), distance: 0,        time: 0,         routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(4), distance: km(27.1), time: mins(78),  routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(3), distance: 0,        time: 0,         routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(2), distance: km(12.6), time: mins(38),  routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(1), distance: 0,        time: 0,         routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(0), distance: km(32.0), time: mins(91),  routes: 1),
+            ]
+            previousPoints = [
+                ChartDataPoint(bucketDate: daysAgo(13), distance: km(14.2), time: mins(43), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(12), distance: 0,        time: 0,        routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(11), distance: km(22.7), time: mins(65), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(10), distance: 0,        time: 0,        routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(9),  distance: km(31.5), time: mins(90), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(8),  distance: 0,        time: 0,        routes: 0),
+                ChartDataPoint(bucketDate: daysAgo(7),  distance: 0,        time: 0,        routes: 0),
+            ]
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.reduce(0)  { $0 + $1.routes }
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.reduce(0) { $0 + $1.routes }
+
+        case .oneMonth:
+            var cPts: [ChartDataPoint] = []
+            let rideOffsets = [0, 2, 4, 7, 9, 11, 14, 16, 18, 21, 23, 25, 27, 29]
+            let distances: [Double] = [32, 18, 25, 41, 15, 28, 22, 36, 19, 27, 33, 21, 29, 24]
+            let times:     [Double] = [91, 52, 71, 117, 43, 80, 63, 102, 54, 77, 94, 60, 83, 68]
+            for (i, offset) in rideOffsets.enumerated() {
+                cPts.append(ChartDataPoint(bucketDate: daysAgo(offset), distance: km(distances[i]), time: mins(times[i]), routes: 1))
+            }
+            currentPoints = cPts
+            previousPoints = [
+                ChartDataPoint(bucketDate: daysAgo(33), distance: km(22), time: mins(63), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(37), distance: km(31), time: mins(89), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(42), distance: km(18), time: mins(51), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(46), distance: km(27), time: mins(77), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(51), distance: km(35), time: mins(100), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(55), distance: km(20), time: mins(57), routes: 1),
+                ChartDataPoint(bucketDate: daysAgo(58), distance: km(29), time: mins(82), routes: 1),
+            ]
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.count
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.count
+
+        case .threeMonths:
+            let weeklyDist: [Double] = [45, 0, 62, 38, 71, 55, 0, 83, 47, 60, 78, 32, 91]
+            let weeklyTime: [Double] = [128, 0, 177, 109, 202, 157, 0, 237, 134, 171, 222, 91, 260]
+            let slots = bucketDates(for: .threeMonths, isCurrent: true, calendar: cal)
+            currentPoints = slots.enumerated().map { i, d in
+                let idx = min(i, weeklyDist.count - 1)
+                return ChartDataPoint(bucketDate: d, distance: km(weeklyDist[idx]), time: mins(weeklyTime[idx]), routes: weeklyDist[idx] > 0 ? Int(weeklyDist[idx] / 20) + 1 : 0)
+            }
+            let prevSlots = bucketDates(for: .threeMonths, isCurrent: false, calendar: cal)
+            let prevDist: [Double] = [30, 58, 0, 44, 67, 80, 0, 39, 72, 51, 0, 68, 43]
+            previousPoints = prevSlots.enumerated().map { i, d in
+                let idx = min(i, prevDist.count - 1)
+                return ChartDataPoint(bucketDate: d, distance: km(prevDist[idx]), time: mins(prevDist[idx] * 2.85), routes: prevDist[idx] > 0 ? Int(prevDist[idx] / 20) + 1 : 0)
+            }
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.reduce(0)  { $0 + $1.routes }
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.reduce(0) { $0 + $1.routes }
+
+        case .sixMonths:
+            let slots = bucketDates(for: .sixMonths, isCurrent: true, calendar: cal)
+            let pattern: [Double] = [0, 38, 61, 22, 74, 55, 0, 83, 47, 29, 68, 90, 41, 55, 0, 72, 38, 65, 88, 47, 0, 59, 76, 31, 84, 52]
+            currentPoints = slots.enumerated().map { i, d in
+                let v = i < pattern.count ? pattern[i] : 0.0
+                return ChartDataPoint(bucketDate: d, distance: km(v), time: mins(v * 2.85), routes: v > 0 ? Int(v / 18) + 1 : 0)
+            }
+            let prevSlots = bucketDates(for: .sixMonths, isCurrent: false, calendar: cal)
+            let prevPat: [Double] = [42, 0, 55, 31, 68, 44, 77, 0, 35, 62, 49, 71, 0, 38, 85, 52, 0, 67, 43, 79, 28, 61, 47, 74, 0, 56]
+            previousPoints = prevSlots.enumerated().map { i, d in
+                let v = i < prevPat.count ? prevPat[i] : 0.0
+                return ChartDataPoint(bucketDate: d, distance: km(v), time: mins(v * 2.85), routes: v > 0 ? Int(v / 18) + 1 : 0)
+            }
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.reduce(0)  { $0 + $1.routes }
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.reduce(0) { $0 + $1.routes }
+
+        case .yearToDate:
+            let slots = bucketDates(for: .yearToDate, isCurrent: true, calendar: cal)
+            // Jan-May (5 months for 2026): realistic winter→spring ramp
+            let ytdDist: [Double] = [120, 180, 240, 310, 280]
+            let ytdTime: [Double] = [342, 514, 686, 886, 800]
+            let ytdRoutes: [Int]  = [6,   9,   12,  16,  14]
+            currentPoints = slots.enumerated().map { i, d in
+                guard i < ytdDist.count else { return ChartDataPoint(bucketDate: d) }
+                return ChartDataPoint(bucketDate: d, distance: km(ytdDist[i]), time: mins(ytdTime[i]), routes: ytdRoutes[i])
+            }
+            let prevSlots = bucketDates(for: .yearToDate, isCurrent: false, calendar: cal)
+            let prevDist: [Double] = [95, 145, 210, 275, 250]
+            let prevTime: [Double] = [271, 414, 600, 786, 714]
+            let prevRoutes: [Int]  = [5,  7,   10,  14,  12]
+            previousPoints = prevSlots.enumerated().map { i, d in
+                guard i < prevDist.count else { return ChartDataPoint(bucketDate: d) }
+                return ChartDataPoint(bucketDate: d, distance: km(prevDist[i]), time: mins(prevTime[i]), routes: prevRoutes[i])
+            }
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.reduce(0)  { $0 + $1.routes }
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.reduce(0) { $0 + $1.routes }
+
+        case .oneYear:
+            let slots = bucketDates(for: .oneYear, isCurrent: true, calendar: cal)
+            // Seasonal pattern: summer peaks, winter low
+            let yearDist:   [Double] = [95, 180, 260, 310, 340, 295, 280, 250, 200, 155, 120, 90]
+            let yearTime:   [Double] = [271, 514, 743, 886, 971, 843, 800, 714, 571, 443, 343, 257]
+            let yearRoutes: [Int]    = [5,   9,   13,  16,  17,  15,  14,  13,  10,  8,   6,   5]
+            currentPoints = slots.enumerated().map { i, d in
+                guard i < yearDist.count else { return ChartDataPoint(bucketDate: d) }
+                return ChartDataPoint(bucketDate: d, distance: km(yearDist[i]), time: mins(yearTime[i]), routes: yearRoutes[i])
+            }
+            let prevSlots = bucketDates(for: .oneYear, isCurrent: false, calendar: cal)
+            let prevDist:   [Double] = [80, 155, 225, 270, 295, 255, 240, 215, 170, 130, 100, 75]
+            let prevTime:   [Double] = [229, 443, 643, 771, 843, 729, 686, 614, 486, 371, 286, 214]
+            let prevRoutes: [Int]    = [4,   8,   11,  14,  15,  13,  12,  11,  9,   7,   5,   4]
+            previousPoints = prevSlots.enumerated().map { i, d in
+                guard i < prevDist.count else { return ChartDataPoint(bucketDate: d) }
+                return ChartDataPoint(bucketDate: d, distance: km(prevDist[i]), time: mins(prevTime[i]), routes: prevRoutes[i])
+            }
+            totalCurrentDistance  = currentPoints.reduce(0)  { $0 + $1.distance }
+            totalCurrentTime      = currentPoints.reduce(0)  { $0 + $1.time }
+            totalCurrentRoutes    = currentPoints.reduce(0)  { $0 + $1.routes }
+            totalPreviousDistance = previousPoints.reduce(0) { $0 + $1.distance }
+            totalPreviousTime     = previousPoints.reduce(0) { $0 + $1.time }
+            totalPreviousRoutes   = previousPoints.reduce(0) { $0 + $1.routes }
+        }
+
+        // Heatmap: 3-5 rides/week spread over the last year
+        heatmapData = [:]
+        heatmapDistanceData = [:]
+        heatmapTimeData = [:]
+        var seed = 42
+        func nextBool(density: Int) -> Bool { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return seed % density == 0 }
+        for dayOffset in 0..<365 {
+            let d = daysAgo(dayOffset)
+            let count = nextBool(density: 3) ? 2 : (nextBool(density: 2) ? 1 : 0)
+            if count > 0 {
+                heatmapData[d] = count
+                // ~15-35 km per ride, ~45-100 min per ride
+                let distPerRide = 15_000.0 + Double((dayOffset * 17 + 3) % 20_000)
+                let timePerRide = 45.0 * 60 + Double((dayOffset * 23 + 7) % 3300)
+                heatmapDistanceData[d] = Double(count) * distPerRide
+                heatmapTimeData[d] = Double(count) * timePerRide
+            }
+        }
+
+        // Speed points: ~2-3 rides/week across the last year, gentle upward trend.
+        // Generated for the full year then filtered to the selected period so the
+        // period picker actually changes what appears in the chart.
+        speedPoints = []
+        for dayOffset in stride(from: 364, through: 0, by: -1) {
+            let r = (dayOffset &* 1103515245 &+ 12345) & 0x7fff_ffff
+            guard r % 3 != 0 else { continue }
+            let fraction = Double(364 - dayOffset) / 364.0
+            let baseKph  = 15.5 + fraction * 6.0
+            let jitter   = Double((r % 300) - 150) / 100.0
+            let kph      = max(13.0, baseKph + jitter)
+            speedPoints.append(SpeedPoint(date: daysAgo(dayOffset), speed: kph / 3.6))
+        }
+        speedPoints.sort { $0.date < $1.date }
+
+        let periodStart: Date
+        switch period {
+        case .oneWeek:     periodStart = daysAgo(6)
+        case .oneMonth:    periodStart = daysAgo(29)
+        case .threeMonths: periodStart = daysAgo(90)
+        case .sixMonths:   periodStart = daysAgo(181)
+        case .yearToDate:
+            let year = cal.component(.year, from: today)
+            var ytdC = DateComponents(); ytdC.year = year; ytdC.month = 1; ytdC.day = 1
+            periodStart = cal.date(from: ytdC) ?? daysAgo(364)
+        case .oneYear:     periodStart = daysAgo(364)
+        }
+        speedPoints = speedPoints.filter { $0.date >= periodStart }
+    }
+    #endif
+}

--- a/Go Cycling/View/Statistics/ActivityHeatmapChart.swift
+++ b/Go Cycling/View/Statistics/ActivityHeatmapChart.swift
@@ -1,0 +1,299 @@
+//
+//  ActivityHeatmapChart.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+import UIKit
+
+// MARK: - Internal data types
+
+fileprivate struct HeatmapDay: Identifiable {
+    var id: Date { date }
+    let date: Date
+    let value: Double
+    let dayOfWeek: Int   // 0 = Mon, 6 = Sun
+    let weekIndex: Int
+}
+
+fileprivate struct HeatmapWeekRow: Identifiable {
+    var id: Int { weekIndex }
+    let weekIndex: Int
+    let slots: [HeatmapDay?]   // always 7 elements
+    let monthLabel: String?    // non-nil = first week of a new calendar month
+    let isMonthStart: Bool
+}
+
+// MARK: - Chart view
+
+@available(iOS 16, *)
+struct ActivityHeatmapChart: View {
+    let valueData: [Date: Double]
+    let metric: ChartMetric
+    let period: ChartPeriod
+    let themeColor: Color
+    let usingMetric: Bool
+
+    @State private var selectedDay: HeatmapDay? = nil
+
+    private static let dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+    private let cellSpacing: CGFloat = 3
+    private let monthLabelWidth: CGFloat = 32
+    private let legendCellSize: CGFloat = 13
+
+    private var maxValue: Double { valueData.values.max() ?? 1 }
+    private var weekRows: [HeatmapWeekRow] { buildWeekRows() }
+
+    // Cell size from screen width; caller applies .padding(.horizontal) = 32pt total
+    private var cellSize: CGFloat {
+        let contentWidth = UIScreen.main.bounds.width - 32
+        return max(28, (contentWidth - monthLabelWidth - 4 - CGFloat(6) * cellSpacing) / 7)
+    }
+
+    // MARK: - Body
+    //
+    // The view IS a ScrollView — it fills whatever space it is given.
+    // The section header (callout + day labels) is pinned so it stays visible while scrolling.
+    // Callers should use .safeAreaInset to add fixed pickers above/below without nesting this
+    // inside another layout container that fights for height.
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
+                Section {
+                    ForEach(weekRows) { row in weekRowView(row) }
+
+                    // Legend at very bottom of scrollable content
+                    legendView
+                        .padding(.horizontal, 4)
+                        .padding(.top, 8)
+                        .padding(.bottom, 12)
+
+                } header: {
+                    // Pinned: callout row + day-of-week labels
+                    VStack(spacing: 0) {
+                        calloutRow
+                            .frame(height: 20)
+                            .padding(.horizontal, 4)
+                            .padding(.top, 8)
+                            .padding(.bottom, 4)
+                        dayHeaderRow
+                            .padding(.bottom, 4)
+                    }
+                    .background(Color(.systemBackground))
+                }
+            }
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var calloutRow: some View {
+        Group {
+            if let day = selectedDay {
+                HStack(spacing: 6) {
+                    Text(formattedDate(day.date))
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    if day.value > 0 {
+                        Text("· \(formattedValue(day.value))")
+                            .font(.caption.bold())
+                    } else {
+                        Text("· No routes")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .transition(.opacity.animation(.easeInOut(duration: 0.15)))
+            } else {
+                Text(" ").font(.caption)
+            }
+        }
+    }
+
+    private var dayHeaderRow: some View {
+        HStack(spacing: 4) {
+            Color.clear.frame(width: monthLabelWidth)
+            HStack(spacing: cellSpacing) {
+                ForEach(0..<7, id: \.self) { col in
+                    Text(ActivityHeatmapChart.dayLabels[col])
+                        .font(.system(size: min(cellSize * 0.28, 11), weight: .medium))
+                        .foregroundColor(.secondary)
+                        .frame(width: cellSize)
+                        .multilineTextAlignment(.center)
+                }
+            }
+        }
+    }
+
+    private func weekRowView(_ row: HeatmapWeekRow) -> some View {
+        let cs = cellSize
+        let cornerRadius = max(4, cs * 0.15)
+        return VStack(spacing: 0) {
+            // Thin divider + breathing room at each month boundary (skip the very first row)
+            if row.isMonthStart && row.weekIndex > 0 {
+                HStack(spacing: 4) {
+                    Color.clear.frame(width: monthLabelWidth)
+                    Color(UIColor.separator).frame(height: 0.5)
+                }
+                .padding(.vertical, 5)
+            }
+
+            HStack(spacing: 4) {
+                // Month label in left gutter (first week of each new month only)
+                if let label = row.monthLabel {
+                    Text(label)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundColor(.secondary)
+                        .frame(width: monthLabelWidth, alignment: .leading)
+                } else {
+                    Color.clear.frame(width: monthLabelWidth)
+                }
+
+                // 7 day cells
+                HStack(spacing: cellSpacing) {
+                    ForEach(0..<7, id: \.self) { col in
+                        if let day = row.slots[col] {
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(cellColor(for: day.value))
+                                .frame(width: cs, height: cs)
+                                .onTapGesture {
+                                    withAnimation {
+                                        selectedDay = (selectedDay?.id == day.id) ? nil : day
+                                    }
+                                }
+                        } else {
+                            RoundedRectangle(cornerRadius: cornerRadius)
+                                .fill(Color(UIColor.systemGray6).opacity(0.3))
+                                .frame(width: cs, height: cs)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, cellSpacing / 2)
+        }
+    }
+
+    private var legendView: some View {
+        HStack(spacing: 4) {
+            Text("Less")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            ForEach([0.0, 0.25, 0.5, 0.75, 1.0] as [Double], id: \.self) { f in
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(legendColor(fraction: f))
+                    .frame(width: legendCellSize, height: legendCellSize)
+            }
+            Text("More")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    // MARK: - Colors
+
+    private func cellColor(for value: Double) -> Color {
+        if value <= 0 { return Color(UIColor.systemGray5) }
+        let linear = min(value / max(maxValue, 1), 1.0)
+        let intensity = sqrt(linear)   // sqrt lifts low values so all metrics look similarly vibrant
+        return themeColor.opacity(0.2 + intensity * 0.8)
+    }
+
+    private func legendColor(fraction: Double) -> Color {
+        if fraction == 0 { return Color(UIColor.systemGray5) }
+        let intensity = sqrt(fraction)
+        return themeColor.opacity(0.2 + intensity * 0.8)
+    }
+
+    // MARK: - Formatting
+
+    private func formattedDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "EEEE, MMM d, yyyy"
+        return f.string(from: date)
+    }
+
+    private func formattedValue(_ value: Double) -> String {
+        switch metric {
+        case .routes:
+            let n = Int(round(value))
+            return "\(n) \(n == 1 ? "route" : "routes")"
+        case .distance:
+            return MetricsFormatting.formatDistance(distance: value, usingMetric: usingMetric)
+        case .time:
+            return MetricsFormatting.formatTime(time: value)
+        }
+    }
+
+    // MARK: - Data building
+
+    private func buildWeekRows() -> [HeatmapWeekRow] {
+        var cal = Calendar.current
+        cal.timeZone = .current
+        cal.firstWeekday = 2   // weeks start on Monday
+
+        let today = cal.startOfDay(for: Date())
+
+        let startDate: Date
+        switch period {
+        case .threeMonths: startDate = cal.date(byAdding: .day, value: -89,  to: today) ?? today
+        case .sixMonths:   startDate = cal.date(byAdding: .day, value: -179, to: today) ?? today
+        case .yearToDate:
+            let year = cal.component(.year, from: today)
+            var c = DateComponents(); c.year = year; c.month = 1; c.day = 1
+            startDate = cal.date(from: c) ?? today
+        case .oneYear:     startDate = cal.date(byAdding: .day, value: -364, to: today) ?? today
+        default:           startDate = cal.date(byAdding: .day, value: -89,  to: today) ?? today
+        }
+
+        var days: [HeatmapDay] = []
+        var current = startDate
+        var weekIndex = 0
+        var lastWeekOfYear = -1
+
+        while current <= today {
+            let weekOfYear = cal.component(.weekOfYear, from: current)
+            if lastWeekOfYear != -1 && weekOfYear != lastWeekOfYear { weekIndex += 1 }
+            lastWeekOfYear = weekOfYear
+
+            let weekday   = cal.component(.weekday, from: current)
+            let dayOfWeek = (weekday + 5) % 7   // 1=Sun→6, 2=Mon→0, …
+
+            days.append(HeatmapDay(date: current, value: valueData[current] ?? 0,
+                                   dayOfWeek: dayOfWeek, weekIndex: weekIndex))
+
+            guard let next = cal.date(byAdding: .day, value: 1, to: current) else { break }
+            current = next
+        }
+
+        let byWeek = Dictionary(grouping: days, by: \.weekIndex)
+        let sortedIndices = byWeek.keys.sorted()
+
+        let monthFmt = DateFormatter()
+        monthFmt.dateFormat = "MMM"
+
+        var rows: [HeatmapWeekRow] = []
+        var prevMonth = -1
+
+        for idx in sortedIndices {
+            let weekDays = byWeek[idx] ?? []
+
+            var slots: [HeatmapDay?] = Array(repeating: nil, count: 7)
+            for d in weekDays { slots[d.dayOfWeek] = d }
+
+            let firstDay  = (0..<7).compactMap { slots[$0] }.first
+            let monthNum  = firstDay.flatMap { cal.dateComponents([.month], from: $0.date).month } ?? -1
+            let isNewMonth = monthNum != prevMonth && monthNum != -1
+            let monthLabel: String? = isNewMonth ? firstDay.map { monthFmt.string(from: $0.date) } : nil
+
+            rows.append(HeatmapWeekRow(weekIndex: idx, slots: slots,
+                                       monthLabel: monthLabel, isMonthStart: isNewMonth))
+
+            if monthNum != -1 { prevMonth = monthNum }
+        }
+
+        return rows
+    }
+}

--- a/Go Cycling/View/Statistics/ActivityHeatmapDetailView.swift
+++ b/Go Cycling/View/Statistics/ActivityHeatmapDetailView.swift
@@ -1,0 +1,134 @@
+//
+//  ActivityHeatmapDetailView.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+
+@available(iOS 16, *)
+struct ActivityHeatmapDetailView: View {
+    private let availablePeriods: [ChartPeriod] = [.threeMonths, .sixMonths, .yearToDate, .oneYear]
+
+    @State private var selectedPeriod: ChartPeriod = .yearToDate
+    @AppStorage("lastHeatmapMetric") private var selectedMetricRaw: Int = ChartMetric.routes.rawValue
+    private var selectedMetric: ChartMetric {
+        get { ChartMetric(rawValue: selectedMetricRaw) ?? .routes }
+        set { selectedMetricRaw = newValue.rawValue }
+    }
+    @StateObject private var viewModel = StatisticsChartsViewModel(period: .yearToDate)
+
+    @EnvironmentObject var preferences: Preferences
+
+    let telemetryManager = TelemetryManager.sharedTelemetryManager
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    // Map the selected metric to the right [Date: Double] dictionary
+    var activeValueData: [Date: Double] {
+        switch selectedMetric {
+        case .routes:   return viewModel.heatmapData.mapValues { Double($0) }
+        case .distance: return viewModel.heatmapDistanceData
+        case .time:     return viewModel.heatmapTimeData
+        }
+    }
+
+    var body: some View {
+        ActivityHeatmapChart(
+            valueData: activeValueData,
+            metric: selectedMetric,
+            period: selectedPeriod,
+            themeColor: themeColor,
+            usingMetric: preferences.usingMetric
+        )
+        .padding(.horizontal)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            VStack(spacing: 0) {
+                Picker("Metric", selection: Binding(
+                    get: { selectedMetric },
+                    set: { selectedMetricRaw = $0.rawValue }
+                )) {
+                    ForEach(ChartMetric.allCases) { metric in
+                        Text(metric.label).tag(metric)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.horizontal)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+                summaryHeader
+                    .padding(.horizontal)
+                    .padding(.bottom, 8)
+            }
+            .background(Color(.systemBackground))
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                Divider()
+                periodPicker
+                    .padding(.horizontal)
+                    .padding(.vertical, 10)
+            }
+            .background(Color(.systemBackground))
+        }
+        .navigationBarTitle("Activity Heatmap", displayMode: .inline)
+        .onAppear {
+            viewModel.loadData(for: selectedPeriod)
+            telemetryManager.sendCyclingSignal(tab: .Statistics, action: .HeatmapView)
+        }
+        .onChange(of: selectedPeriod) { newPeriod in
+            viewModel.loadData(for: newPeriod)
+        }
+    }
+
+    private var summaryHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(selectedPeriod.displayName)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            Group {
+                switch selectedMetric {
+                case .routes:
+                    Text("\(viewModel.totalCurrentRoutes) \(viewModel.totalCurrentRoutes == 1 ? "route" : "routes")")
+                case .distance:
+                    Text(MetricsFormatting.formatDistance(distance: viewModel.totalCurrentDistance, usingMetric: preferences.usingMetric))
+                case .time:
+                    Text(MetricsFormatting.formatTime(time: viewModel.totalCurrentTime))
+                }
+            }
+            .font(.title2.bold())
+        }
+    }
+
+    private var periodPicker: some View {
+        HStack(spacing: 0) {
+            ForEach(availablePeriods) { period in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedPeriod = period
+                    }
+                } label: {
+                    Text(period.label)
+                        .font(.system(size: 13, weight: selectedPeriod == period ? .bold : .regular))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(selectedPeriod == period ? themeColor.opacity(0.15) : Color.clear)
+                        )
+                        .foregroundColor(selectedPeriod == period ? themeColor : .primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.systemGray6))
+        )
+    }
+}

--- a/Go Cycling/View/Statistics/CyclingBarChart.swift
+++ b/Go Cycling/View/Statistics/CyclingBarChart.swift
@@ -1,0 +1,228 @@
+//
+//  CyclingBarChart.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+import Charts
+
+@available(iOS 16, *)
+struct CyclingBarChart: View {
+    let points: [ChartDataPoint]
+    let previousPoints: [ChartDataPoint]
+    let showPrevious: Bool
+    let period: ChartPeriod
+    let metric: ChartMetric
+    let themeColor: Color
+    let usingMetric: Bool
+
+    @State private var selectedBucketDate: Date? = nil
+
+    // Shift previous-period dates forward so they land on the same x-axis as current
+    private var shiftedPreviousPoints: [ChartDataPoint] {
+        guard showPrevious else { return [] }
+        let cal = Calendar.current
+        return previousPoints.map { pt in
+            ChartDataPoint(
+                bucketDate: shiftedDate(pt.bucketDate, calendar: cal),
+                distance: pt.distance,
+                time: pt.time,
+                routes: pt.routes
+            )
+        }
+    }
+
+    private func shiftedDate(_ date: Date, calendar: Calendar) -> Date {
+        switch period {
+        case .oneWeek:     return calendar.date(byAdding: .day,   value: 7,   to: date) ?? date
+        case .oneMonth:    return calendar.date(byAdding: .day,   value: 30,  to: date) ?? date
+        case .threeMonths: return calendar.date(byAdding: .day,   value: 91,  to: date) ?? date
+        case .sixMonths:   return calendar.date(byAdding: .day,   value: 182, to: date) ?? date
+        case .yearToDate:  return calendar.date(byAdding: .year,  value: 1,   to: date) ?? date
+        case .oneYear:     return calendar.date(byAdding: .month, value: 12,  to: date) ?? date
+        }
+    }
+
+    var selectedPoint: ChartDataPoint? {
+        guard let selected = selectedBucketDate, !points.isEmpty else { return nil }
+        return points.min(by: {
+            abs($0.bucketDate.timeIntervalSince(selected)) < abs($1.bucketDate.timeIntervalSince(selected))
+        })
+    }
+
+    var selectedPreviousPoint: ChartDataPoint? {
+        guard showPrevious, let current = selectedPoint else { return nil }
+        guard let idx = points.firstIndex(where: { $0.id == current.id }),
+              idx < previousPoints.count else { return nil }
+        return previousPoints[idx]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Fixed-height callout (3 lines always to prevent layout jump)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(selectedPoint.map { bucketLabel(for: $0.bucketDate) } ?? " ")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Text(selectedPoint.map { formattedValue($0) } ?? " ")
+                    .font(.title3.bold())
+                Text(selectedPreviousPoint.map { "Prev: \(formattedValue($0))" } ?? " ")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 4)
+
+            if points.isEmpty {
+                Text("No routes in this period")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(maxHeight: .infinity)
+            } else {
+                Chart {
+                    ForEach(points) { point in
+                        LineMark(
+                            x: .value("Date", point.bucketDate, unit: calendarUnit),
+                            y: .value(metric.label, point.value(for: metric))
+                        )
+                        .foregroundStyle(by: .value("Series", "Current"))
+                        .lineStyle(StrokeStyle(lineWidth: 2.5))
+                    }
+
+                    if showPrevious {
+                        ForEach(shiftedPreviousPoints) { point in
+                            LineMark(
+                                x: .value("Date", point.bucketDate, unit: calendarUnit),
+                                y: .value(metric.label, point.value(for: metric))
+                            )
+                            .foregroundStyle(by: .value("Series", "Previous"))
+                            .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [5, 3]))
+                        }
+                    }
+
+                    ForEach(points) { point in
+                        PointMark(
+                            x: .value("Date", point.bucketDate, unit: calendarUnit),
+                            y: .value(metric.label, point.value(for: metric))
+                        )
+                        .foregroundStyle(by: .value("Series", "Current"))
+                        .symbolSize(selectedBucketDate != nil && selectedPoint?.id == point.id ? 350 : 180)
+                    }
+
+                    if showPrevious {
+                        ForEach(shiftedPreviousPoints) { point in
+                            PointMark(
+                                x: .value("Date", point.bucketDate, unit: calendarUnit),
+                                y: .value(metric.label, point.value(for: metric))
+                            )
+                            .foregroundStyle(by: .value("Series", "Previous"))
+                            .symbolSize(110)
+                        }
+                    }
+                }
+                .chartForegroundStyleScale([
+                    "Current":  themeColor,
+                    "Previous": themeColor.opacity(0.4)
+                ])
+                .chartLegend(.hidden)
+                .chartXAxis {
+                    AxisMarks { value in
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel {
+                                Text(period.formatXLabel(date))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        if let v = value.as(Double.self) {
+                            AxisValueLabel {
+                                Text(compactYLabel(v))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                    }
+                }
+                .chartOverlay { proxy in
+                    GeometryReader { geo in
+                        Rectangle()
+                            .fill(Color.clear)
+                            .contentShape(Rectangle())
+                            .gesture(
+                                DragGesture(minimumDistance: 0)
+                                    .onChanged { val in
+                                        let xPos = val.location.x - geo[proxy.plotAreaFrame].origin.x
+                                        if let date: Date = proxy.value(atX: xPos) {
+                                            selectedBucketDate = date
+                                        }
+                                    }
+                                    .onEnded { _ in
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                            withAnimation { selectedBucketDate = nil }
+                                        }
+                                    }
+                            )
+                    }
+                }
+                .frame(maxHeight: .infinity)
+            }
+        }
+    }
+
+    private var calendarUnit: Calendar.Component {
+        switch period {
+        case .oneWeek, .oneMonth:      return .day
+        case .threeMonths, .sixMonths: return .weekOfYear
+        case .yearToDate, .oneYear:    return .month
+        }
+    }
+
+    private func bucketLabel(for date: Date) -> String {
+        let f = DateFormatter()
+        switch period {
+        case .oneWeek:
+            f.dateFormat = "EEEE, MMM d"
+            return f.string(from: date)
+        case .oneMonth:
+            f.dateFormat = "MMM d, yyyy"
+            return f.string(from: date)
+        case .threeMonths, .sixMonths:
+            let end = Calendar.current.date(byAdding: .day, value: 6, to: date) ?? date
+            f.dateFormat = "MMM d"
+            return "\(f.string(from: date)) – \(f.string(from: end))"
+        case .yearToDate, .oneYear:
+            f.dateFormat = "MMMM yyyy"
+            return f.string(from: date)
+        }
+    }
+
+    private func formattedValue(_ point: ChartDataPoint) -> String {
+        switch metric {
+        case .distance: return MetricsFormatting.formatDistance(distance: point.distance, usingMetric: usingMetric)
+        case .time:     return MetricsFormatting.formatTime(time: point.time)
+        case .routes:   return "\(point.routes) \(point.routes == 1 ? "route" : "routes")"
+        }
+    }
+
+    private func compactYLabel(_ value: Double) -> String {
+        switch metric {
+        case .distance:
+            let converted = usingMetric ? value / 1000 : value * 0.000621371
+            if converted >= 1000 { return String(format: "%.0fk", converted / 1000) }
+            return String(format: "%.0f", converted)
+        case .time:
+            let hours = Int(value) / 3600
+            let mins  = (Int(value) % 3600) / 60
+            if hours > 0 { return "\(hours)h" }
+            return "\(mins)m"
+        case .routes:
+            return "\(Int(value))"
+        }
+    }
+}

--- a/Go Cycling/View/Statistics/CyclingChartsDetailView.swift
+++ b/Go Cycling/View/Statistics/CyclingChartsDetailView.swift
@@ -1,0 +1,128 @@
+//
+//  CyclingChartsDetailView.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+
+@available(iOS 16, *)
+struct CyclingChartsDetailView: View {
+    @AppStorage("lastChartPeriod") private var lastChartPeriodRaw: Int = ChartPeriod.oneWeek.rawValue
+
+    @State private var selectedPeriod: ChartPeriod = .oneWeek
+    @State private var selectedMetric: ChartMetric = .distance
+    @State private var showPrevious: Bool = false
+    @StateObject private var viewModel = StatisticsChartsViewModel(period: .oneWeek)
+
+    @EnvironmentObject var preferences: Preferences
+
+    let telemetryManager = TelemetryManager.sharedTelemetryManager
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Metric picker
+            Picker("Metric", selection: $selectedMetric) {
+                ForEach(ChartMetric.allCases) { metric in
+                    Text(metric.label).tag(metric)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .padding(.bottom, 8)
+
+            // Line chart — fills all remaining vertical space
+            CyclingBarChart(
+                points: viewModel.currentPoints,
+                previousPoints: viewModel.previousPoints,
+                showPrevious: showPrevious,
+                period: selectedPeriod,
+                metric: selectedMetric,
+                themeColor: themeColor,
+                usingMetric: preferences.usingMetric
+            )
+            .padding(.horizontal)
+            .frame(maxHeight: .infinity)
+            .id(selectedPeriod.rawValue)
+
+            Divider()
+
+            // vs Previous Period toggle
+            HStack {
+                Text("vs Previous Period")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Toggle("", isOn: $showPrevious)
+                    .labelsHidden()
+                    .tint(themeColor)
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            // Period picker
+            periodPicker
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+        }
+        .navigationBarTitle(selectedPeriod.displayName, displayMode: .inline)
+        .onAppear {
+            let period = ChartPeriod(rawValue: lastChartPeriodRaw) ?? .oneWeek
+            selectedPeriod = period
+            viewModel.loadData(for: period)
+            telemetryManager.sendCyclingSignal(tab: .Statistics, action: telemetryAction(for: period))
+        }
+        .onChange(of: selectedPeriod) { newPeriod in
+            lastChartPeriodRaw = newPeriod.rawValue
+            viewModel.loadData(for: newPeriod)
+            telemetryManager.sendCyclingSignal(tab: .Statistics, action: telemetryAction(for: newPeriod))
+        }
+    }
+
+    private var periodPicker: some View {
+        HStack(spacing: 0) {
+            ForEach(ChartPeriod.allCases) { period in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedPeriod = period
+                    }
+                } label: {
+                    Text(period.label)
+                        .font(.system(size: 13, weight: selectedPeriod == period ? .bold : .regular))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(selectedPeriod == period ? themeColor.opacity(0.15) : Color.clear)
+                        )
+                        .foregroundColor(selectedPeriod == period ? themeColor : .primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.systemGray6))
+        )
+    }
+
+    private func telemetryAction(for period: ChartPeriod) -> TelemetryCyclingAction {
+        switch period {
+        case .oneWeek:     return .OneWeek
+        case .oneMonth:    return .OneMonth
+        case .threeMonths: return .ThreeMonths
+        case .sixMonths:   return .SixMonths
+        case .yearToDate:  return .YearToDate
+        case .oneYear:     return .OneYear
+        }
+    }
+}

--- a/Go Cycling/View/Statistics/CyclingChartsView.swift
+++ b/Go Cycling/View/Statistics/CyclingChartsView.swift
@@ -8,7 +8,228 @@
 import SwiftUI
 import CoreData
 
+// MARK: - Section container (shown inside StatisticsView's Form)
+
 struct CyclingChartsView: View {
+    var body: some View {
+        Section(header: Text(RecordsFormatting.headerStrings[1]), footer: Text(RecordsFormatting.footerStrings[0])) {
+            if #available(iOS 16, *) {
+                NewChartRows()
+            } else {
+                LegacyChartRows()
+            }
+        }
+    }
+}
+
+// MARK: - iOS 16+ rows
+
+@available(iOS 16, *)
+private struct NewChartRows: View {
+    var body: some View {
+        NavigationLink(destination: CyclingChartsDetailView()) {
+            CyclingChartsMiniCard()
+        }
+        NavigationLink(destination: ActivityHeatmapDetailView()) {
+            HeatmapMiniCard()
+        }
+        NavigationLink(destination: SpeedTrendDetailView()) {
+            SpeedTrendMiniCard()
+        }
+    }
+}
+
+// MARK: - iOS 16+ mini cards
+
+@available(iOS 16, *)
+private struct CyclingChartsMiniCard: View {
+    @AppStorage("lastChartPeriod") private var lastChartPeriodRaw: Int = ChartPeriod.oneWeek.rawValue
+    @StateObject private var loader = ChartMiniCardLoader()
+    @EnvironmentObject var preferences: Preferences
+
+    var period: ChartPeriod { ChartPeriod(rawValue: lastChartPeriodRaw) ?? .oneWeek }
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("Cycling Charts")
+                    .font(.headline)
+                    .foregroundColor(themeColor)
+                Spacer()
+                Text(period.label)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Capsule().fill(Color(.systemGray5)))
+            }
+            HStack {
+                Text("Distance")
+                Spacer()
+                Text(MetricsFormatting.formatDistance(distance: loader.totalDistance, usingMetric: preferences.usingMetric))
+                    .bold()
+                Text(loader.changeString(for: loader.distanceChangePct))
+                    .bold()
+                    .foregroundColor(loader.distanceChangePct >= 0 ? .green : .red)
+            }
+            HStack {
+                Text("Time")
+                Spacer()
+                Text(MetricsFormatting.formatTime(time: loader.totalTime))
+                    .bold()
+                Text(loader.changeString(for: loader.timeChangePct))
+                    .bold()
+                    .foregroundColor(loader.timeChangePct >= 0 ? .green : .red)
+            }
+            HStack {
+                Text("Routes")
+                Spacer()
+                Text("\(loader.totalRoutes)")
+                    .bold()
+                Text(loader.changeString(for: loader.routesChangePct))
+                    .bold()
+                    .foregroundColor(loader.routesChangePct >= 0 ? .green : .red)
+            }
+        }
+        .onAppear { loader.load(period: period) }
+        .onChange(of: lastChartPeriodRaw) { _ in loader.load(period: period) }
+    }
+}
+
+@available(iOS 16, *)
+private class ChartMiniCardLoader: ObservableObject {
+    @Published var totalDistance: Double = 0
+    @Published var totalTime: Double = 0
+    @Published var distanceChangePct: Double = 0
+    @Published var timeChangePct: Double = 0
+    @Published var routesChangePct: Double = 0
+    @Published var totalRoutes: Int = 0
+
+    func changeString(for pct: Double) -> String {
+        let rounded = Int(round(pct))
+        if rounded == 0 { return "0%" }
+        let sym = rounded > 0 ? "↑" : "↓"
+        let mag = abs(rounded) < 999 ? "\(abs(rounded))" : ">999"
+        return "\(sym)\(mag)%"
+    }
+
+    func load(period: ChartPeriod) {
+        let vm = StatisticsChartsViewModel(period: period)
+        totalDistance  = vm.totalCurrentDistance
+        totalTime      = vm.totalCurrentTime
+        totalRoutes    = vm.totalCurrentRoutes
+        distanceChangePct = vm.distanceChangePct
+        timeChangePct     = vm.timeChangePct
+        let prev = vm.totalPreviousRoutes
+        routesChangePct = prev > 0
+            ? Double(vm.totalCurrentRoutes - prev) / Double(prev) * 100
+            : (vm.totalCurrentRoutes > 0 ? 100 : 0)
+    }
+}
+
+@available(iOS 16, *)
+private struct HeatmapMiniCard: View {
+    @StateObject private var loader = HeatmapMiniCardLoader()
+    @EnvironmentObject var preferences: Preferences
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("Activity Heatmap")
+                    .font(.headline)
+                    .foregroundColor(themeColor)
+                Spacer()
+            }
+            HStack {
+                Text("This year")
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text("\(loader.yearlyRideCount) \(loader.yearlyRideCount == 1 ? "route" : "routes")")
+                    .bold()
+            }
+        }
+        .onAppear { loader.load() }
+    }
+}
+
+@available(iOS 16, *)
+private class HeatmapMiniCardLoader: ObservableObject {
+    @Published var yearlyRideCount: Int = 0
+
+    func load() {
+        let vm = StatisticsChartsViewModel(period: .yearToDate)
+        yearlyRideCount = vm.totalCurrentRoutes
+    }
+}
+
+@available(iOS 16, *)
+private struct SpeedTrendMiniCard: View {
+    @StateObject private var loader = SpeedMiniCardLoader()
+    @EnvironmentObject var preferences: Preferences
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            HStack {
+                Text("Speed Trend")
+                    .font(.headline)
+                    .foregroundColor(themeColor)
+                Spacer()
+            }
+            HStack {
+                Text("Past 30 days")
+                    .foregroundColor(.secondary)
+                Spacer()
+                Text(loader.avgSpeedString(usingMetric: preferences.usingMetric))
+                    .bold()
+                Text(loader.changeString)
+                    .bold()
+                    .foregroundColor(loader.speedChangePct >= 0 ? .green : .red)
+            }
+        }
+        .onAppear { loader.load() }
+    }
+}
+
+@available(iOS 16, *)
+private class SpeedMiniCardLoader: ObservableObject {
+    @Published var avgSpeed: Double = 0    // m/s
+    @Published var speedChangePct: Double = 0
+
+    var changeString: String {
+        let rounded = Int(round(speedChangePct))
+        if rounded == 0 { return "0%" }
+        let sym = rounded > 0 ? "↑" : "↓"
+        let mag = abs(rounded) < 999 ? "\(abs(rounded))" : ">999"
+        return "\(sym)\(mag)%"
+    }
+
+    func avgSpeedString(usingMetric: Bool) -> String {
+        guard avgSpeed > 0 else { return "No routes" }
+        return MetricsFormatting.formatSingleSpeed(speed: avgSpeed, usingMetric: usingMetric)
+    }
+
+    func load() {
+        let vm = StatisticsChartsViewModel(period: .oneMonth)
+        avgSpeed       = vm.avgCurrentSpeed
+        speedChangePct = vm.speedChangePct
+    }
+}
+
+// MARK: - Legacy iOS 14/15 rows (unchanged from original CyclingChartsView logic)
+
+private struct LegacyChartRows: View {
     var invalidData: Bool
     @FetchRequest var bikeRidesIn1Week: FetchedResults<BikeRide>
     @FetchRequest var bikeRidesIn1WeekBefore: FetchedResults<BikeRide>
@@ -19,124 +240,86 @@ struct CyclingChartsView: View {
 
     init() {
         self.invalidData = false
-        
+
         let requests: [NSFetchRequest<BikeRide>?] = BikeRide.fetchRequestsWithDateRanges()
         let countNils = requests.filter({ $0 == nil }).count
-        // Use default fetch requests if any of the date range requests failed
-        if (countNils > 0 && requests.count == 6) {
+        if countNils > 0 && requests.count == 6 {
             self.invalidData = true
             let request: NSFetchRequest<BikeRide> = BikeRide.fetchRequest()
             request.sortDescriptors = []
-            self._bikeRidesIn1Week = FetchRequest<BikeRide>(fetchRequest: request)
-            self._bikeRidesIn1WeekBefore = FetchRequest<BikeRide>(fetchRequest: request)
-            self._bikeRidesIn5Weeks = FetchRequest<BikeRide>(fetchRequest: request)
-            self._bikeRidesIn5WeeksBefore = FetchRequest<BikeRide>(fetchRequest: request)
-            self._bikeRidesIn26Weeks = FetchRequest<BikeRide>(fetchRequest: request)
+            self._bikeRidesIn1Week         = FetchRequest<BikeRide>(fetchRequest: request)
+            self._bikeRidesIn1WeekBefore   = FetchRequest<BikeRide>(fetchRequest: request)
+            self._bikeRidesIn5Weeks        = FetchRequest<BikeRide>(fetchRequest: request)
+            self._bikeRidesIn5WeeksBefore  = FetchRequest<BikeRide>(fetchRequest: request)
+            self._bikeRidesIn26Weeks       = FetchRequest<BikeRide>(fetchRequest: request)
             self._bikeRidesIn26WeeksBefore = FetchRequest<BikeRide>(fetchRequest: request)
-        }
-        // Otherwise, use the correct date range requests - it is safe to force unwrap here
-        else {
-            self._bikeRidesIn1Week = FetchRequest<BikeRide>(fetchRequest: requests[0]!)
-            self._bikeRidesIn1WeekBefore = FetchRequest<BikeRide>(fetchRequest: requests[1]!)
-            self._bikeRidesIn5Weeks = FetchRequest<BikeRide>(fetchRequest: requests[2]!)
-            self._bikeRidesIn5WeeksBefore = FetchRequest<BikeRide>(fetchRequest: requests[3]!)
-            self._bikeRidesIn26Weeks = FetchRequest<BikeRide>(fetchRequest: requests[4]!)
+        } else {
+            self._bikeRidesIn1Week         = FetchRequest<BikeRide>(fetchRequest: requests[0]!)
+            self._bikeRidesIn1WeekBefore   = FetchRequest<BikeRide>(fetchRequest: requests[1]!)
+            self._bikeRidesIn5Weeks        = FetchRequest<BikeRide>(fetchRequest: requests[2]!)
+            self._bikeRidesIn5WeeksBefore  = FetchRequest<BikeRide>(fetchRequest: requests[3]!)
+            self._bikeRidesIn26Weeks       = FetchRequest<BikeRide>(fetchRequest: requests[4]!)
             self._bikeRidesIn26WeeksBefore = FetchRequest<BikeRide>(fetchRequest: requests[5]!)
         }
     }
-    
+
     var body: some View {
-        Section (header: Text(RecordsFormatting.headerStrings[1]), footer: Text(RecordsFormatting.footerStrings[0])) {
-            if (!self.invalidData) {
-                List {
-                    ForEach (0..<3) { index in
-                        NavigationLink(destination: BarChartView(index: index)) {
-                            SingleChartListCellView(distances: self.getDistanceData(index: index), times: self.getTimeData(index: index), numberOfRoutes: self.getNumberOfRoutes(index: index), index: index)
-                        }
-                    }
+        if !self.invalidData {
+            ForEach(0..<3) { index in
+                NavigationLink(destination: BarChartView(index: index)) {
+                    SingleChartListCellView(
+                        distances: getDistanceData(index: index),
+                        times: getTimeData(index: index),
+                        numberOfRoutes: getNumberOfRoutes(index: index),
+                        index: index
+                    )
                 }
             }
-            else {
-                Text("Unable to retrieve cycling data at this time.")
-            }
+        } else {
+            Text("Unable to retrieve cycling data at this time.")
         }
     }
-    
-    // Functions to extract important data from the fetched data
+
     func getDistanceData(index: Int) -> [Double] {
         var result: [Double] = [0.0, 0.0]
-        if (index == 0) {
-            for entry in bikeRidesIn1WeekBefore {
-                result[0] += entry.cyclingDistance
-            }
-            for entry in bikeRidesIn1Week {
-                result[1] += entry.cyclingDistance
-            }
-        }
-        if (index == 1) {
-            for entry in bikeRidesIn5WeeksBefore {
-                result[0] += entry.cyclingDistance
-            }
-            for entry in bikeRidesIn5Weeks {
-                result[1] += entry.cyclingDistance
-            }
-        }
-        if (index == 2) {
-            for entry in bikeRidesIn26WeeksBefore {
-                result[0] += entry.cyclingDistance
-            }
-            for entry in bikeRidesIn26Weeks {
-                result[1] += entry.cyclingDistance
-            }
+        switch index {
+        case 0:
+            for e in bikeRidesIn1WeekBefore { result[0] += e.cyclingDistance }
+            for e in bikeRidesIn1Week       { result[1] += e.cyclingDistance }
+        case 1:
+            for e in bikeRidesIn5WeeksBefore { result[0] += e.cyclingDistance }
+            for e in bikeRidesIn5Weeks        { result[1] += e.cyclingDistance }
+        case 2:
+            for e in bikeRidesIn26WeeksBefore { result[0] += e.cyclingDistance }
+            for e in bikeRidesIn26Weeks        { result[1] += e.cyclingDistance }
+        default: break
         }
         return result
     }
-    
+
     func getTimeData(index: Int) -> [Double] {
         var result: [Double] = [0.0, 0.0]
-        if (index == 0) {
-            for entry in bikeRidesIn1WeekBefore {
-                result[0] += entry.cyclingTime
-            }
-            for entry in bikeRidesIn1Week {
-                result[1] += entry.cyclingTime
-            }
-        }
-        if (index == 1) {
-            for entry in bikeRidesIn5WeeksBefore {
-                result[0] += entry.cyclingTime
-            }
-            for entry in bikeRidesIn5Weeks {
-                result[1] += entry.cyclingTime
-            }
-        }
-        if (index == 2) {
-            for entry in bikeRidesIn26WeeksBefore {
-                result[0] += entry.cyclingTime
-            }
-            for entry in bikeRidesIn26Weeks {
-                result[1] += entry.cyclingTime
-            }
+        switch index {
+        case 0:
+            for e in bikeRidesIn1WeekBefore { result[0] += e.cyclingTime }
+            for e in bikeRidesIn1Week       { result[1] += e.cyclingTime }
+        case 1:
+            for e in bikeRidesIn5WeeksBefore { result[0] += e.cyclingTime }
+            for e in bikeRidesIn5Weeks        { result[1] += e.cyclingTime }
+        case 2:
+            for e in bikeRidesIn26WeeksBefore { result[0] += e.cyclingTime }
+            for e in bikeRidesIn26Weeks        { result[1] += e.cyclingTime }
+        default: break
         }
         return result
     }
-    
+
     func getNumberOfRoutes(index: Int) -> [Int] {
-        if (index == 0) {
-            return [bikeRidesIn1WeekBefore.count, bikeRidesIn1Week.count]
+        switch index {
+        case 0: return [bikeRidesIn1WeekBefore.count,   bikeRidesIn1Week.count]
+        case 1: return [bikeRidesIn5WeeksBefore.count,  bikeRidesIn5Weeks.count]
+        case 2: return [bikeRidesIn26WeeksBefore.count, bikeRidesIn26Weeks.count]
+        default: return [0, 0]
         }
-        if (index == 1) {
-            return [bikeRidesIn5WeeksBefore.count, bikeRidesIn5Weeks.count]
-        }
-        if (index == 2) {
-            return [bikeRidesIn26WeeksBefore.count, bikeRidesIn26Weeks.count]
-        }
-        return [0, 0]
     }
 }
-
-//struct CyclingChartsView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        CyclingChartsView()
-//    }
-//}

--- a/Go Cycling/View/Statistics/SpeedTrendChart.swift
+++ b/Go Cycling/View/Statistics/SpeedTrendChart.swift
@@ -1,0 +1,139 @@
+//
+//  SpeedTrendChart.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+import Charts
+
+@available(iOS 16, *)
+struct SpeedTrendChart: View {
+    let speedPoints: [StatisticsChartsViewModel.SpeedPoint]
+    let themeColor: Color
+    let usingMetric: Bool
+
+    @State private var selectedDate: Date? = nil
+
+    private func convertedSpeed(_ mps: Double) -> Double {
+        usingMetric ? mps * 3.6 : mps * 2.23694
+    }
+
+    private var speedUnit: String {
+        MetricsFormatting.getSpeedUnits(usingMetric: usingMetric)
+    }
+
+    var selectedPoint: StatisticsChartsViewModel.SpeedPoint? {
+        guard let selected = selectedDate, !speedPoints.isEmpty else { return nil }
+        return speedPoints.min(by: {
+            abs($0.date.timeIntervalSince(selected)) < abs($1.date.timeIntervalSince(selected))
+        })
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Group {
+                if let point = selectedPoint {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(formattedDate(point.date))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Text(MetricsFormatting.formatSingleSpeed(speed: point.speed, usingMetric: usingMetric))
+                            .font(.title3.bold())
+                    }
+                } else {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(" ").font(.caption)
+                        Text(" ").font(.title3.bold())
+                    }
+                }
+            }
+            .padding(.horizontal, 4)
+
+            if speedPoints.isEmpty {
+                Text("No routes in this period")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .frame(maxHeight: .infinity)
+            } else {
+                Chart(speedPoints) { point in
+                    LineMark(
+                        x: .value("Date", point.date, unit: .day),
+                        y: .value("Speed", convertedSpeed(point.speed))
+                    )
+                    .foregroundStyle(themeColor)
+                    .lineStyle(StrokeStyle(lineWidth: 2))
+
+                    if speedPoints.count <= 20 {
+                        PointMark(
+                            x: .value("Date", point.date, unit: .day),
+                            y: .value("Speed", convertedSpeed(point.speed))
+                        )
+                        .foregroundStyle(
+                            selectedPoint?.id == point.id ? themeColor : themeColor.opacity(0.4)
+                        )
+                        .symbolSize(selectedPoint?.id == point.id ? 80 : 36)
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks { value in
+                        if let date = value.as(Date.self) {
+                            AxisValueLabel {
+                                Text(shortDate(date))
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        if let v = value.as(Double.self) {
+                            AxisValueLabel {
+                                Text("\(Int(v)) \(speedUnit)")
+                                    .font(.caption2)
+                            }
+                        }
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [3]))
+                    }
+                }
+                .chartOverlay { proxy in
+                    GeometryReader { geo in
+                        Rectangle()
+                            .fill(Color.clear)
+                            .contentShape(Rectangle())
+                            .gesture(
+                                DragGesture(minimumDistance: 0)
+                                    .onChanged { val in
+                                        let xPos = val.location.x - geo[proxy.plotAreaFrame].origin.x
+                                        if let date: Date = proxy.value(atX: xPos) {
+                                            selectedDate = date
+                                        }
+                                    }
+                                    .onEnded { _ in
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                                            withAnimation { selectedDate = nil }
+                                        }
+                                    }
+                            )
+                    }
+                }
+                .frame(maxHeight: .infinity)
+            }
+        }
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "EEEE, MMM d, yyyy"
+        return f.string(from: date)
+    }
+
+    private func shortDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f.string(from: date)
+    }
+}

--- a/Go Cycling/View/Statistics/SpeedTrendDetailView.swift
+++ b/Go Cycling/View/Statistics/SpeedTrendDetailView.swift
@@ -1,0 +1,103 @@
+//
+//  SpeedTrendDetailView.swift
+//  Go Cycling
+//
+//  Created by Anthony Hopkins on 2026-05-23.
+//
+
+import SwiftUI
+
+@available(iOS 16, *)
+struct SpeedTrendDetailView: View {
+    @State private var selectedPeriod: ChartPeriod = .oneMonth
+    @StateObject private var viewModel = StatisticsChartsViewModel(period: .oneMonth)
+
+    @EnvironmentObject var preferences: Preferences
+
+    let telemetryManager = TelemetryManager.sharedTelemetryManager
+
+    var themeColor: Color {
+        Color(UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted))
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Summary header
+            summaryHeader
+                .padding(.horizontal)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+
+            // Chart fills all remaining space
+            SpeedTrendChart(
+                speedPoints: viewModel.speedPoints,
+                themeColor: themeColor,
+                usingMetric: preferences.usingMetric
+            )
+            .padding(.horizontal)
+            .frame(maxHeight: .infinity)
+
+            Divider()
+
+            // Period picker
+            periodPicker
+                .padding(.horizontal)
+                .padding(.vertical, 10)
+        }
+        .navigationBarTitle("Speed Trend", displayMode: .inline)
+        .onAppear {
+            viewModel.loadData(for: selectedPeriod)
+            telemetryManager.sendCyclingSignal(tab: .Statistics, action: .SpeedTrendView)
+        }
+        .onChange(of: selectedPeriod) { newPeriod in
+            viewModel.loadData(for: newPeriod)
+        }
+    }
+
+    private var summaryHeader: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(selectedPeriod.displayName)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            if viewModel.avgCurrentSpeed > 0 {
+                Text(MetricsFormatting.formatSingleSpeed(speed: viewModel.avgCurrentSpeed, usingMetric: preferences.usingMetric))
+                    .font(.title2.bold())
+                Text("Average speed")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("No routes")
+                    .font(.title2.bold())
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var periodPicker: some View {
+        HStack(spacing: 0) {
+            ForEach(ChartPeriod.allCases) { period in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        selectedPeriod = period
+                    }
+                } label: {
+                    Text(period.label)
+                        .font(.system(size: 13, weight: selectedPeriod == period ? .bold : .regular))
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 6)
+                        .background(
+                            RoundedRectangle(cornerRadius: 6)
+                                .fill(selectedPeriod == period ? themeColor.opacity(0.15) : Color.clear)
+                        )
+                        .foregroundColor(selectedPeriod == period ? themeColor : .primary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(4)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(.systemGray6))
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces custom bar charts on the Statistics tab with SwiftCharts (iOS 16+), with the existing custom charts as a fallback for iOS 14/15
- Adds three new full-screen chart views: **Cycling Charts** (bar chart with period picker + vs-last-period comparison), **Activity Heatmap** (calendar-style ride frequency/distance/time grid), and **Speed Trend** (per-ride line chart)
- Period picker covers 1W / 1M / 3M / 6M / YTD / 1Y across all chart types; last-selected period and heatmap metric are persisted via `@AppStorage`

## New files

- `Model/ChartPeriod.swift`, `Model/ChartDataPoint.swift`
- `ViewModel/Statistics/StatisticsChartsViewModel.swift`
- `View/Statistics/CyclingChartsDetailView.swift`, `CyclingBarChart.swift`
- `View/Statistics/ActivityHeatmapDetailView.swift`, `ActivityHeatmapChart.swift`
- `View/Statistics/SpeedTrendDetailView.swift`, `SpeedTrendChart.swift`

## Test plan

- [ ] Build on iOS 16+ simulator → Statistics tab shows 3 new chart rows
- [ ] Cycling Charts: period picker animates between all 6 periods, metric picker (Distance / Time / Routes) switches data, Δ% comparison strip updates
- [ ] Activity Heatmap: metric picker (Routes / Distance / Time) changes heatmap colors, sqrt-scaled vibrancy, last metric persisted across navigation
- [ ] Speed Trend: one point per ride, period filter narrows the range, dots hidden when > 20 rides
- [ ] Simulate iOS 14/15 → legacy 3-row bar chart path works unchanged
- [ ] Theme color applies to all chart components
- [ ] Metric/imperial preference applies to distance and speed values

🤖 Generated with [Claude Code](https://claude.com/claude-code)