### PR TITLE
Add floating stats card and full-screen map to ride detail view

### DIFF
--- a/Go Cycling/View/History/RouteDetailMapView.swift
+++ b/Go Cycling/View/History/RouteDetailMapView.swift
@@ -24,6 +24,7 @@ struct RouteDetailMapView: UIViewRepresentable {
     let center: CLLocationCoordinate2D
     let span: CLLocationDegrees
     let routeColor: UIColor
+    var bottomInset: CGFloat = 0
 
     func makeCoordinator() -> Coordinator {
         Coordinator(routeColor: routeColor)
@@ -65,13 +66,15 @@ struct RouteDetailMapView: UIViewRepresentable {
         mapView.showsCompass = false
         mapView.isScrollEnabled = true
         mapView.isZoomEnabled = true
-        mapView.setRegion(
-            MKCoordinateRegion(
-                center: center,
-                span: MKCoordinateSpan(latitudeDelta: span, longitudeDelta: span)
-            ),
-            animated: false
-        )
+        let topLeft = MKMapPoint(CLLocationCoordinate2D(latitude: center.latitude + span / 2, longitude: center.longitude - span / 2))
+        let bottomRight = MKMapPoint(CLLocationCoordinate2D(latitude: center.latitude - span / 2, longitude: center.longitude + span / 2))
+        let mapRect = MKMapRect(x: min(topLeft.x, bottomRight.x),
+                                y: min(topLeft.y, bottomRight.y),
+                                width: abs(topLeft.x - bottomRight.x),
+                                height: abs(topLeft.y - bottomRight.y))
+        mapView.setVisibleMapRect(mapRect,
+                                  edgePadding: UIEdgeInsets(top: 40, left: 20, bottom: bottomInset + 20, right: 20),
+                                  animated: false)
         return mapView
     }
 

--- a/Go Cycling/View/History/SingleBikeRideView.swift
+++ b/Go Cycling/View/History/SingleBikeRideView.swift
@@ -12,32 +12,76 @@ import MapKit
 struct SingleBikeRideView: View {
     let bikeRide: BikeRide
     let navigationTitle: String
-    
+
     @EnvironmentObject var preferences: Preferences
-    
+
     @State private var showingEditPopover = false
-    
+    @State private var statsExpanded = true
+
     let telemetryManager = TelemetryManager.sharedTelemetryManager
     let telemetryTab = TelemetryTab.History
-    
+
     var body: some View {
-        GeometryReader { (geometry) in
-            VStack {
-                VStack (spacing: 0) {
-                    if (preferences.namedRoutes && bikeRide.cyclingRouteName != "Uncategorized") {
-                        Text("\(bikeRide.cyclingRouteName)")
-                            .bold()
-                            .padding(.top, 10)
+        ZStack(alignment: .bottom) {
+            RouteDetailMapView(
+                coordinates: self.setupCoordinates(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
+                center: self.calculateCenter(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
+                span: self.calculateSpan(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
+                routeColor: UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted),
+                bottomInset: 175
+            )
+            .ignoresSafeArea(edges: .bottom)
+
+            statsCard
+        }
+        .ignoresSafeArea(edges: .bottom)
+        .navigationBarTitle(navigationTitle, displayMode: .inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if (preferences.namedRoutes) {
+                    Button {
+                        self.showingEditPopover = true
+                        telemetryManager.sendCyclingSignal(tab: telemetryTab, action: TelemetryCyclingAction.EditRoute)
+                    } label: {
+                        Image(systemName: "pencil")
                     }
-                    RouteDetailMapView(
-                        coordinates: self.setupCoordinates(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
-                        center: self.calculateCenter(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
-                        span: self.calculateSpan(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
-                        routeColor: UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted)
-                    )
-                    .padding(.bottom, 10)
                 }
-                if (min(geometry.size.width, geometry.size.height) < 600) {
+            }
+        }
+        .sheet(isPresented: $showingEditPopover) {
+            RouteNameModalView(showEditModal: $showingEditPopover, bikeRideToEdit: bikeRide)
+        }
+        .background(TabBarHider())
+        .onAppear {
+            telemetryManager.sendCyclingSignal(tab: telemetryTab, action: TelemetryCyclingAction.Click)
+        }
+    }
+
+    @ViewBuilder
+    var cardBackground: some View {
+        if #available(iOS 15.0, *) {
+            RoundedRectangle(cornerRadius: 20).fill(.ultraThinMaterial)
+        } else {
+            RoundedRectangle(cornerRadius: 20).fill(Color(UIColor.systemBackground).opacity(0.92))
+        }
+    }
+
+    @ViewBuilder
+    var statsCard: some View {
+        VStack(spacing: 0) {
+            Capsule()
+                .fill(Color.secondary.opacity(0.4))
+                .frame(width: 36, height: 4)
+                .padding(.top, 8)
+                .padding(.bottom, 6)
+
+            if statsExpanded {
+                VStack(spacing: 0) {
+                    if preferences.namedRoutes && bikeRide.cyclingRouteName != "Uncategorized" {
+                        Text(bikeRide.cyclingRouteName)
+                            .font(.headline)
+                            .padding(.bottom, 8)
+                    }
                     VStack(spacing: 10) {
                         HStack {
                             Spacer()
@@ -56,140 +100,92 @@ struct SingleBikeRideView: View {
                             Spacer()
                         }
                     }
-                    .padding(.bottom, 10)
+                    .padding(.bottom, 12)
                 }
-                else {
-                    HStack {
-                        Spacer()
-                        HStack {
-                            HistoryMetricView(systemImageString: "location", metricName: "Distance", metricText: MetricsFormatting.formatDistance(distance: bikeRide.cyclingDistance, usingMetric: preferences.usingMetric))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "timer", metricName: "Time", metricText: MetricsFormatting.formatTime(time: bikeRide.cyclingTime))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "arrow.up.arrow.down", metricName: "Elev. Gain", metricText: MetricsFormatting.formatElevation(elevations: bikeRide.cyclingElevations, usingMetric: preferences.usingMetric))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "speedometer", metricName: "Average Speed", metricText: MetricsFormatting.formatAverageSpeed(speeds: bikeRide.cyclingSpeeds, distance: bikeRide.cyclingDistance, time: bikeRide.cyclingTime, usingMetric: preferences.usingMetric))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "speedometer", metricName: "Top Speed", metricText: MetricsFormatting.formatTopSpeed(speeds: bikeRide.cyclingSpeeds, usingMetric: preferences.usingMetric))
-                        }
-                        .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10))
-                        Spacer()
-                    }
-                    .padding(.bottom, 10)
+                .transition(.opacity)
+            } else {
+                HStack(spacing: 20) {
+                    Label(MetricsFormatting.formatDistance(distance: bikeRide.cyclingDistance, usingMetric: preferences.usingMetric), systemImage: "location")
+                    Label(MetricsFormatting.formatTime(time: bikeRide.cyclingTime), systemImage: "timer")
                 }
+                .font(.subheadline)
+                .padding(.bottom, 12)
+                .transition(.opacity)
             }
-        }
-        .navigationBarTitle(navigationTitle, displayMode: .inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                if (preferences.namedRoutes) {
-                    Button {
-                        self.showingEditPopover = true
 
-                        telemetryManager.sendCyclingSignal(
-                            tab: telemetryTab,
-                            action: TelemetryCyclingAction.EditRoute
-                        )
-                    } label: {
-                        Image(systemName: "pencil")
-                    }
-                }
+            // Buffer so content clears the home indicator
+            Spacer().frame(height: 28)
+        }
+        .frame(maxWidth: .infinity)
+        .background(cardBackground)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .padding(.horizontal, 12)
+        .onTapGesture {
+            withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {
+                statsExpanded.toggle()
             }
-        }
-        .sheet(isPresented: $showingEditPopover) {
-            RouteNameModalView(showEditModal: $showingEditPopover, bikeRideToEdit: bikeRide)
-        }
-        .onAppear {
-            telemetryManager.sendCyclingSignal(
-                tab: telemetryTab,
-                action: TelemetryCyclingAction.Click
-            )
         }
     }
-    
+
     func setupCoordinates(latitudes: [CLLocationDegrees], longitudes: [CLLocationDegrees]) -> [CLLocationCoordinate2D] {
         var coordinates: [CLLocationCoordinate2D] = []
-        
         var locationsCount = latitudes.count
-        if (latitudes.count > longitudes.count) {
-            locationsCount = longitudes.count
-        }
-        
+        if (latitudes.count > longitudes.count) { locationsCount = longitudes.count }
         for index in 0..<locationsCount {
             coordinates.append(CLLocationCoordinate2DMake(latitudes[index], longitudes[index]))
         }
-        
         return coordinates
     }
-    
+
     func calculateSpan(latitudes: [CLLocationDegrees], longitudes: [CLLocationDegrees]) -> CLLocationDegrees {
-        // Find the min and max latitude and longitude to find ideal span that fits entire route
         if (latitudes.count > 0 && longitudes.count > 0) {
-            var maxLatitude: CLLocationDegrees = latitudes[0]
-            var minLatitude: CLLocationDegrees = latitudes[0]
-            var maxLongitude: CLLocationDegrees = longitudes[0]
-            var minLongitude: CLLocationDegrees = longitudes[0]
-            
+            var maxLatitude = latitudes[0], minLatitude = latitudes[0]
+            var maxLongitude = longitudes[0], minLongitude = longitudes[0]
             for latitude in latitudes {
-                if (latitude < minLatitude) {
-                    minLatitude = latitude
-                }
-                if (latitude > maxLatitude) {
-                    maxLatitude = latitude
-                }
+                if latitude < minLatitude { minLatitude = latitude }
+                if latitude > maxLatitude { maxLatitude = latitude }
             }
-            
             for longitude in longitudes {
-                if (longitude < minLongitude) {
-                    minLongitude = longitude
-                }
-                if (longitude > maxLongitude) {
-                    maxLongitude = longitude
-                }
+                if longitude < minLongitude { minLongitude = longitude }
+                if longitude > maxLongitude { maxLongitude = longitude }
             }
-            
-            // Add 10% extra so that there is some space around the map
             let latitudeSpan = (maxLatitude - minLatitude) * 1.1
             let longitudeSpan = (maxLongitude - minLongitude) * 1.1
             return latitudeSpan > longitudeSpan ? latitudeSpan : longitudeSpan
         }
-        else {
-            return 0.1
-        }
+        return 0.1
     }
-    
+
     func calculateCenter(latitudes: [CLLocationDegrees], longitudes: [CLLocationDegrees]) -> CLLocationCoordinate2D {
-        // Find the min and max latitude and longitude to find ideal span that fits entire route
         if (latitudes.count > 0 && longitudes.count > 0) {
-            var maxLatitude: CLLocationDegrees = latitudes[0]
-            var minLatitude: CLLocationDegrees = latitudes[0]
-            var maxLongitude: CLLocationDegrees = longitudes[0]
-            var minLongitude: CLLocationDegrees = longitudes[0]
-            
+            var maxLatitude = latitudes[0], minLatitude = latitudes[0]
+            var maxLongitude = longitudes[0], minLongitude = longitudes[0]
             for latitude in latitudes {
-                if (latitude < minLatitude) {
-                    minLatitude = latitude
-                }
-                if (latitude > maxLatitude) {
-                    maxLatitude = latitude
-                }
+                if latitude < minLatitude { minLatitude = latitude }
+                if latitude > maxLatitude { maxLatitude = latitude }
             }
-            
             for longitude in longitudes {
-                if (longitude < minLongitude) {
-                    minLongitude = longitude
-                }
-                if (longitude > maxLongitude) {
-                    maxLongitude = longitude
-                }
+                if longitude < minLongitude { minLongitude = longitude }
+                if longitude > maxLongitude { maxLongitude = longitude }
             }
-            
-            let latitudeMidpoint = (maxLatitude + minLatitude)/2
-            let longitudeMidpoint = (maxLongitude + minLongitude)/2
-            return CLLocationCoordinate2D(latitude: latitudeMidpoint, longitude: longitudeMidpoint)
+            return CLLocationCoordinate2D(latitude: (maxLatitude + minLatitude) / 2,
+                                          longitude: (maxLongitude + minLongitude) / 2)
         }
-        else {
-            return CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        return CLLocationCoordinate2D(latitude: 0, longitude: 0)
+    }
+}
+
+private struct TabBarHider: UIViewControllerRepresentable {
+    final class Controller: UIViewController {
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            tabBarController?.tabBar.isHidden = true
+        }
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            tabBarController?.tabBar.isHidden = false
         }
     }
+    func makeUIViewController(context: Context) -> Controller { Controller() }
+    func updateUIViewController(_ uiViewController: Controller, context: Context) {}
 }


### PR DESCRIPTION
## Summary

- Full-screen interactive map with the route, start/end dots, and correct initial framing
- Stats card floats over the bottom of the map, anchored at the screen edge
- Tap the card to collapse to a compact distance + time pill; tap again to expand
- Tab bar is hidden for this view and restored on navigate-back
- `.ultraThinMaterial` blur background on iOS 15+, opaque fallback on iOS 14

## Changes

**`RouteDetailMapView.swift`**
- Adds `bottomInset: CGFloat` parameter (default 0)
- Replaces `setRegion` with `setVisibleMapRect(_:edgePadding:)` so the route is framed above the card on first load

**`SingleBikeRideView.swift`**
- Replaces `GeometryReader → VStack` layout with `ZStack(alignment: .bottom)`
- Map uses `.ignoresSafeArea(edges: .bottom)` for full-bleed; ZStack also ignores safe area so the card anchors at screen edge
- `statsCard` computed property — expanded shows all 5 metrics in the existing two-row grid; collapsed shows distance + time `Label` pair
- `TabBarHider` private `UIViewControllerRepresentable` hides and restores the tab bar via `tabBarController?.tabBar.isHidden`
- `cardBackground` `@ViewBuilder` property handles the iOS 14/15 material difference

## Test plan

- [x] Build succeeds
- [x] History → tap a ride: full-screen map, full route visible above the card
- [x] Card floats at the screen bottom with rounded top corners
- [x] Tap card → collapses to pill (distance + time); tap again → expands
- [x] Spring animation is smooth
- [x] Tab bar is hidden while in this view, reappears on back navigation
- [x] Named route label appears in the card when applicable
- [x] Edit (pencil) button in nav bar still works
- [x] Colour preference change redraws the route colour

🤖 Generated with [Claude Code](https://claude.com/claude-code)