### PR TITLE
Redesign ride detail metrics card and fix elevation accuracy

### DIFF
--- a/Go Cycling/Model/MetricsFormatting.swift
+++ b/Go Cycling/Model/MetricsFormatting.swift
@@ -18,10 +18,12 @@ class MetricsFormatting {
     
     static func formatStartTime(date: Date) -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.amSymbol = "AM"
-        dateFormatter.pmSymbol = "PM"
-        dateFormatter.dateFormat = "h:mm a"
-        return(dateFormatter.string(from: date))
+        dateFormatter.timeStyle = .short
+        return dateFormatter.string(from: date)
+    }
+
+    static func formatDateAndTime(date: Date) -> String {
+        "\(formatDate(date: date)) · \(formatStartTime(date: date))"
     }
     
     static func formatDistance(distance: CLLocationDistance, usingMetric: Bool) -> String {

--- a/Go Cycling/Model/MetricsFormatting.swift
+++ b/Go Cycling/Model/MetricsFormatting.swift
@@ -79,19 +79,31 @@ class MetricsFormatting {
     static func formatElevation(elevations: [CLLocationDistance], usingMetric: Bool) -> String {
         var elevationGain: CLLocationDistance = 0.0
         let elevationUnits = usingMetric ? "m" : "ft"
-        
+        let threshold: CLLocationDistance = 5.0
+
         for index in 0..<elevations.count {
-            if (index > 0) {
-                if (elevations[index] > elevations[index-1]) {
-                    elevationGain += elevations[index] - elevations[index-1]
+            if index > 0 {
+                let delta = elevations[index] - elevations[index - 1]
+                if delta > threshold {
+                    elevationGain += delta
                 }
             }
         }
-        
+
         let elevationMetres = round(100 * elevationGain)/100
         let elevationFeet = round(100 * (3.28084 * elevationGain))/100
         let elevationString = "\(usingMetric ? elevationMetres : elevationFeet) " + elevationUnits
         return elevationString
+    }
+
+    static func formatMaxElevation(elevations: [CLLocationDistance], usingMetric: Bool) -> String {
+        guard let maxElevation = elevations.max() else {
+            return usingMetric ? "0 m" : "0 ft"
+        }
+        let elevationUnits = usingMetric ? "m" : "ft"
+        let elevationMetres = round(100 * maxElevation) / 100
+        let elevationFeet = round(100 * (3.28084 * maxElevation)) / 100
+        return "\(usingMetric ? elevationMetres : elevationFeet) " + elevationUnits
     }
     
     static func formatTopSpeed(speeds: [CLLocationSpeed], usingMetric: Bool) -> String {

--- a/Go Cycling/View Model/Cycle/LocationViewModel.swift
+++ b/Go Cycling/View Model/Cycle/LocationViewModel.swift
@@ -91,7 +91,7 @@ class LocationViewModel: NSObject, ObservableObject, CLLocationManagerDelegate {
         lastLocation = location
         cyclingLocations.append(lastLocation)
         cyclingSpeed = location.speed
-        cyclingAltitude = location.altitude
+        cyclingAltitude = (location.verticalAccuracy > 0 && location.verticalAccuracy < 30) ? location.altitude : nil
         cyclingSpeeds.append(cyclingSpeed)
         cyclingAltitudes.append(cyclingAltitude)
 

--- a/Go Cycling/View/History/BikeRideListView.swift
+++ b/Go Cycling/View/History/BikeRideListView.swift
@@ -173,7 +173,7 @@ struct ListView: View {
         if (bikeRides.count > 0) {
             List {
                 ForEach(bikeRides) { bikeRide in
-                    NavigationLink(destination: SingleBikeRideView(bikeRide: bikeRide, navigationTitle: MetricsFormatting.formatDate(date: bikeRide.cyclingStartTime))) {
+                    NavigationLink(destination: SingleBikeRideView(bikeRide: bikeRide, navigationTitle: MetricsFormatting.formatDateAndTime(date: bikeRide.cyclingStartTime))) {
                         // Bike ride list cell
                         VStack(spacing: 10) {
                             HStack {

--- a/Go Cycling/View/History/HistoryMetricView.swift
+++ b/Go Cycling/View/History/HistoryMetricView.swift
@@ -11,19 +11,28 @@ struct HistoryMetricView: View {
     let systemImageString: String
     let metricName: String
     let metricText: String
-    
+
     var body: some View {
-        VStack(alignment: .center, spacing: 10) {
-            HStack (spacing: 10) {
-                Text(metricName)
-                    .minimumScaleFactor(0.3)
-                    .lineLimit(1)
-                Image(systemName: systemImageString)
-            }
+        VStack(alignment: .center, spacing: 4) {
+            Image(systemName: systemImageString)
+                .font(.title3)
+                .foregroundColor(.accentColor)
+            Text(metricName)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
             Text(metricText)
-                .font(.title)
-                .minimumScaleFactor(0.3)
+                .font(.headline)
+                .minimumScaleFactor(0.5)
                 .lineLimit(1)
         }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.primary.opacity(0.06))
+        )
     }
 }

--- a/Go Cycling/View/History/SingleBikeRideView.swift
+++ b/Go Cycling/View/History/SingleBikeRideView.swift
@@ -28,7 +28,7 @@ struct SingleBikeRideView: View {
                 center: self.calculateCenter(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
                 span: self.calculateSpan(latitudes: bikeRide.cyclingLatitudes, longitudes: bikeRide.cyclingLongitudes),
                 routeColor: UserPreferences.convertColourChoiceToUIColor(colour: preferences.colourChoiceConverted),
-                bottomInset: 175,
+                bottomInset: 220,
                 mapType: preferences.mapTypeChoiceConverted.mkMapType
             )
             .ignoresSafeArea(edges: .bottom)
@@ -83,24 +83,15 @@ struct SingleBikeRideView: View {
                             .font(.headline)
                             .padding(.bottom, 8)
                     }
-                    VStack(spacing: 10) {
-                        HStack {
-                            Spacer()
-                            HistoryMetricView(systemImageString: "location", metricName: "Distance", metricText: MetricsFormatting.formatDistance(distance: bikeRide.cyclingDistance, usingMetric: preferences.usingMetric))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "timer", metricName: "Time", metricText: MetricsFormatting.formatTime(time: bikeRide.cyclingTime))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "arrow.up.arrow.down", metricName: "Elev. Gain", metricText: MetricsFormatting.formatElevation(elevations: bikeRide.cyclingElevations, usingMetric: preferences.usingMetric))
-                            Spacer()
-                        }
-                        HStack {
-                            Spacer()
-                            HistoryMetricView(systemImageString: "speedometer", metricName: "Average Speed", metricText: MetricsFormatting.formatAverageSpeed(speeds: bikeRide.cyclingSpeeds, distance: bikeRide.cyclingDistance, time: bikeRide.cyclingTime, usingMetric: preferences.usingMetric))
-                            Spacer()
-                            HistoryMetricView(systemImageString: "speedometer", metricName: "Top Speed", metricText: MetricsFormatting.formatTopSpeed(speeds: bikeRide.cyclingSpeeds, usingMetric: preferences.usingMetric))
-                            Spacer()
-                        }
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())], spacing: 8) {
+                        HistoryMetricView(systemImageString: "location", metricName: "Distance", metricText: MetricsFormatting.formatDistance(distance: bikeRide.cyclingDistance, usingMetric: preferences.usingMetric))
+                        HistoryMetricView(systemImageString: "timer", metricName: "Time", metricText: MetricsFormatting.formatTime(time: bikeRide.cyclingTime))
+                        HistoryMetricView(systemImageString: "arrow.up.arrow.down", metricName: "Elev. Gain", metricText: MetricsFormatting.formatElevation(elevations: bikeRide.cyclingElevations, usingMetric: preferences.usingMetric))
+                        HistoryMetricView(systemImageString: "speedometer", metricName: "Avg Speed", metricText: MetricsFormatting.formatAverageSpeed(speeds: bikeRide.cyclingSpeeds, distance: bikeRide.cyclingDistance, time: bikeRide.cyclingTime, usingMetric: preferences.usingMetric))
+                        HistoryMetricView(systemImageString: "speedometer", metricName: "Top Speed", metricText: MetricsFormatting.formatTopSpeed(speeds: bikeRide.cyclingSpeeds, usingMetric: preferences.usingMetric))
+                        HistoryMetricView(systemImageString: "arrow.up.to.line", metricName: "Max Elev.", metricText: MetricsFormatting.formatMaxElevation(elevations: bikeRide.cyclingElevations, usingMetric: preferences.usingMetric))
                     }
+                    .padding(.horizontal, 8)
                     .padding(.bottom, 12)
                 }
                 .transition(.opacity)
@@ -120,6 +111,7 @@ struct SingleBikeRideView: View {
         .frame(maxWidth: .infinity)
         .background(cardBackground)
         .clipShape(RoundedRectangle(cornerRadius: 20))
+        .frame(maxWidth: 560)
         .padding(.horizontal, 12)
         .onTapGesture {
             withAnimation(.spring(response: 0.35, dampingFraction: 0.75)) {


### PR DESCRIPTION
## Summary

- Replaces the asymmetric 3+2 metric layout with a clean 3×2 `LazyVGrid` of individual tiles, each showing an accent-coloured icon, a secondary label, and a bold value
- Adds **max elevation** as the 6th metric to complete the symmetric grid
- Fixes elevation gain significantly over-counting due to GPS noise accumulating with no threshold — consecutive altitude deltas below 5m are now ignored
- Filters out unreliable altitude readings during recording (`verticalAccuracy < 0` or `> 30m`)
- Caps the metrics card at 560pt wide on iPad so it doesn't stretch awkwardly across the full screen

## Test plan

- [ ] Open a saved ride and verify all 6 metrics display correctly in the 3×2 grid
- [ ] Verify elevation gain values look more realistic (less inflated) on existing rides
- [ ] Record a short new ride and confirm elevation data is captured with accuracy filtering
- [ ] Test on iPad to confirm the card stays centred and doesn't stretch full-width
- [ ] Tap the card to collapse/expand and verify both states still look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)