### PR TITLE
Fix elevation gain showing 0 on all rides

### DIFF
--- a/Go Cycling/Model/MetricsFormatting.swift
+++ b/Go Cycling/Model/MetricsFormatting.swift
@@ -81,13 +81,18 @@ class MetricsFormatting {
     static func formatElevation(elevations: [CLLocationDistance], usingMetric: Bool) -> String {
         var elevationGain: CLLocationDistance = 0.0
         let elevationUnits = usingMetric ? "m" : "ft"
-        let threshold: CLLocationDistance = 5.0
 
-        for index in 0..<elevations.count {
-            if index > 0 {
-                let delta = elevations[index] - elevations[index - 1]
-                if delta > threshold {
-                    elevationGain += delta
+        if !elevations.isEmpty {
+            // Hysteresis: only count a rise as real once it exceeds 3m above the last low point.
+            // This filters GPS noise while still accumulating gradual climbs correctly.
+            let threshold: CLLocationDistance = 3.0
+            var baseline = elevations[0]
+            for elevation in elevations {
+                if elevation < baseline {
+                    baseline = elevation
+                } else if elevation > baseline + threshold {
+                    elevationGain += elevation - baseline
+                    baseline = elevation
                 }
             }
         }


### PR DESCRIPTION
## Summary

Regression fix for #24. The per-step 5m threshold applied to consecutive GPS readings caused elevation gain to show 0 on all rides.

**Root cause:** With `distanceFilter = 10`, GPS updates fire every ~10m of travel. A real 5% grade only produces ~0.5m of altitude change per step, so a 5m threshold filtered out all real elevation — not just noise.

**Fix:** Replace the per-step threshold with a hysteresis/baseline algorithm. The last low-point is tracked, and a rise is only counted once it exceeds 3m above that baseline. This means:
- Gradual hills accumulate correctly across many small steps
- Short GPS noise spikes under 3m are ignored
- Sustained real climbing is always captured regardless of gradient

## Test plan

- [ ] Verify existing rides now show non-zero elevation gain again
- [ ] Verify a flat ride still shows 0 (or near 0)
- [ ] Verify a hilly ride shows a reasonable, non-inflated value

🤖 Generated with [Claude Code](https://claude.com/claude-code)